### PR TITLE
Develop

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor' // 사용자가 만든 문서 셋팅과 아이디의 지원이 가능해짐
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 
     //QueryDSL 설정
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta' // Spring 3.0이상의 경우 셋팅법

--- a/src/main/java/com/studyproject/boardproject/controller/ArticleController.java
+++ b/src/main/java/com/studyproject/boardproject/controller/ArticleController.java
@@ -1,8 +1,11 @@
 package com.studyproject.boardproject.controller;
 
-import com.studyproject.boardproject.domain.type.SearchType;
-import com.studyproject.boardproject.response.ArticleResponse;
-import com.studyproject.boardproject.response.ArticleWithCommentsResponse;
+import com.studyproject.boardproject.domain.constant.FormStatus;
+import com.studyproject.boardproject.domain.constant.SearchType;
+import com.studyproject.boardproject.dto.UserAccountDto;
+import com.studyproject.boardproject.dto.request.ArticleRequest;
+import com.studyproject.boardproject.dto.response.ArticleResponse;
+import com.studyproject.boardproject.dto.response.ArticleWithCommentsResponse;
 import com.studyproject.boardproject.service.ArticleService;
 import com.studyproject.boardproject.service.PaginationService;
 import lombok.RequiredArgsConstructor;
@@ -12,10 +15,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -47,16 +47,17 @@ public class ArticleController {
 
     @GetMapping("/{articleId}")
     public String article(@PathVariable Long articleId, ModelMap map) {
-        ArticleWithCommentsResponse article = ArticleWithCommentsResponse.from(articleService.getArticle(articleId));
+        ArticleWithCommentsResponse article = ArticleWithCommentsResponse.from(articleService.getArticleWithComments(articleId));
 
         map.addAttribute("article",article);
         map.addAttribute("articleComments", article.articleCommentsResponse());
+        map.addAttribute("totalCount", articleService.getArticleCount());
 
         return "articles/detail";
     }
 
     @GetMapping("/search-hashtag")
-    public String searchHashtag(
+    public String searchArticleHashtag(
             @RequestParam(required = false) String searchValue,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             ModelMap map
@@ -73,5 +74,45 @@ public class ArticleController {
         map.addAttribute("searchType", SearchType.HASHTAG);
 
         return "articles/search-hashtag";
+    }
+
+    @GetMapping("/form")
+    public String postNewArticle(ArticleRequest articleRequest) {
+        // TODO: 인증 정보를 넣어줘야 한다.
+        articleService.saveArticle(articleRequest.toDto(
+                UserAccountDto.of(
+                    "hyeon", "dummy", "hyeon@mail.com", "Hyeon", "memo", null, null, null, null
+                )));
+
+        return "redirect:/articles";
+    }
+
+    @GetMapping("/{articleId}/form")
+    public String updateArticleForm(@PathVariable Long articleId, ModelMap map) {
+        ArticleResponse article = ArticleResponse.from(articleService.getArticle(articleId));
+
+        map.addAttribute("article", article);
+        map.addAttribute("formStatus", FormStatus.UPDATE);
+
+        return "articles/form";
+
+    }
+
+    @PostMapping("/{articleId}/form")
+    public String updateArticle(@PathVariable Long articleId, ArticleRequest articleRequest) {
+        // TODO: 인증정보를 넣어줘야한다.
+        articleService.updateArticle(articleId, articleRequest.toDto(
+                UserAccountDto.of(
+                        "hyeon", "dummy", "hyeon@mail.com", "Hyeon", "memo", null, null, null, null
+                )));
+
+        return "redirect:/articles/" + articleId;
+    }
+
+    @PostMapping("/{articleId}/delete")
+    public String deleteArticle(@PathVariable Long articleId) {
+        articleService.deleteArticle(articleId);
+
+        return "redirect:/articles";
     }
 }

--- a/src/main/java/com/studyproject/boardproject/domain/constant/FormStatus.java
+++ b/src/main/java/com/studyproject/boardproject/domain/constant/FormStatus.java
@@ -1,0 +1,16 @@
+package com.studyproject.boardproject.domain.constant;
+
+import lombok.Getter;
+
+public enum FormStatus {
+    CREATE("저장", false),
+    UPDATE("수정", true);
+
+    @Getter private final String description;
+    @Getter private final Boolean update;
+
+    FormStatus(String description, Boolean update) {
+        this.description = description;
+        this.update = update;
+    }
+}

--- a/src/main/java/com/studyproject/boardproject/domain/constant/SearchType.java
+++ b/src/main/java/com/studyproject/boardproject/domain/constant/SearchType.java
@@ -1,4 +1,4 @@
-package com.studyproject.boardproject.domain.type;
+package com.studyproject.boardproject.domain.constant;
 
 import lombok.Getter;
 

--- a/src/main/java/com/studyproject/boardproject/dto/ArticleCommentDto.java
+++ b/src/main/java/com/studyproject/boardproject/dto/ArticleCommentDto.java
@@ -15,6 +15,11 @@ public record ArticleCommentDto(
         LocalDateTime modifiedAt,
         String modifiedBy
 ) {
+
+    public static ArticleCommentDto of(Long articleId, UserAccountDto userAccountDto, String content) {
+        return new ArticleCommentDto(null, articleId, userAccountDto, content, null, null, null, null);
+    }
+
     public static ArticleCommentDto of(Long id, Long articleId, UserAccountDto userAccountDto, String content, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
         return new ArticleCommentDto(id, articleId, userAccountDto, content, createdAt, createdBy, modifiedAt, modifiedBy);
     }

--- a/src/main/java/com/studyproject/boardproject/dto/ArticleDto.java
+++ b/src/main/java/com/studyproject/boardproject/dto/ArticleDto.java
@@ -1,6 +1,7 @@
 package com.studyproject.boardproject.dto;
 
 import com.studyproject.boardproject.domain.Article;
+import com.studyproject.boardproject.domain.UserAccount;
 
 import java.time.LocalDateTime;
 
@@ -15,6 +16,11 @@ public record ArticleDto(
         LocalDateTime modifiedAt,
         String modifiedBy
 ) {
+
+    public static ArticleDto of(UserAccountDto userAccountDto, String title, String content, String hashtag) {
+        return new ArticleDto(null, userAccountDto, title, content, hashtag, null, null, null, null);
+    }
+
     public static ArticleDto of(Long id, UserAccountDto userAccountDto, String title, String content, String hashtag, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
         return new ArticleDto(id, userAccountDto, title, content, hashtag, createdAt, createdBy, modifiedAt, modifiedBy);
     }
@@ -33,9 +39,9 @@ public record ArticleDto(
         );
     }
 
-    public Article toEntity() {
+    public Article toEntity(UserAccount userAccount) {
         return Article.of(
-                userAccountDto.toEntity(),
+                userAccount,
                 title,
                 content,
                 hashtag

--- a/src/main/java/com/studyproject/boardproject/dto/UserAccountDto.java
+++ b/src/main/java/com/studyproject/boardproject/dto/UserAccountDto.java
@@ -5,7 +5,6 @@ import com.studyproject.boardproject.domain.UserAccount;
 import java.time.LocalDateTime;
 
 public record UserAccountDto(
-        Long id,
         String userId,
         String userPassword,
         String email,
@@ -16,13 +15,12 @@ public record UserAccountDto(
         LocalDateTime modifiedAt,
         String modifiedBy
 ) {
-    public static UserAccountDto of(Long id, String userId, String userPassword, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
-        return new UserAccountDto(id, userId, userPassword, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
+    public static UserAccountDto of(String userId, String userPassword, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new UserAccountDto(userId, userPassword, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
     }
 
     public static UserAccountDto from(UserAccount entity) {
         return new UserAccountDto(
-                entity.getId(),
                 entity.getUserId(),
                 entity.getUserPassword(),
                 entity.getEmail(),

--- a/src/main/java/com/studyproject/boardproject/dto/request/ArticleCommentRequest.java
+++ b/src/main/java/com/studyproject/boardproject/dto/request/ArticleCommentRequest.java
@@ -1,0 +1,19 @@
+package com.studyproject.boardproject.dto.request;
+
+import com.studyproject.boardproject.dto.ArticleCommentDto;
+import com.studyproject.boardproject.dto.UserAccountDto;
+
+public record ArticleCommentRequest(Long articleId, String content) {
+
+    public static ArticleCommentRequest of(Long articleId, String content) {
+        return new ArticleCommentRequest(articleId, content);
+    }
+
+    public ArticleCommentDto toDto(UserAccountDto userAccountDto) {
+        return ArticleCommentDto.of(
+                articleId,
+                userAccountDto,
+                content
+        );
+    }
+}

--- a/src/main/java/com/studyproject/boardproject/dto/request/ArticleRequest.java
+++ b/src/main/java/com/studyproject/boardproject/dto/request/ArticleRequest.java
@@ -1,0 +1,23 @@
+package com.studyproject.boardproject.dto.request;
+
+import com.studyproject.boardproject.dto.ArticleDto;
+import com.studyproject.boardproject.dto.UserAccountDto;
+
+public record ArticleRequest(
+        String title,
+        String content,
+        String hashtag
+) {
+    public static ArticleRequest of(String title, String content, String hashtag) {
+        return new ArticleRequest(title, content, hashtag);
+    }
+
+    public ArticleDto toDto(UserAccountDto userAccountDto) {
+        return ArticleDto.of(
+                userAccountDto,
+                title,
+                content,
+                hashtag
+        );
+    }
+}

--- a/src/main/java/com/studyproject/boardproject/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/com/studyproject/boardproject/dto/response/ArticleCommentResponse.java
@@ -1,4 +1,4 @@
-package com.studyproject.boardproject.response;
+package com.studyproject.boardproject.dto.response;
 
 import com.studyproject.boardproject.dto.ArticleCommentDto;
 

--- a/src/main/java/com/studyproject/boardproject/dto/response/ArticleResponse.java
+++ b/src/main/java/com/studyproject/boardproject/dto/response/ArticleResponse.java
@@ -1,4 +1,4 @@
-package com.studyproject.boardproject.response;
+package com.studyproject.boardproject.dto.response;
 
 import com.studyproject.boardproject.dto.ArticleDto;
 

--- a/src/main/java/com/studyproject/boardproject/dto/response/ArticleWithCommentsResponse.java
+++ b/src/main/java/com/studyproject/boardproject/dto/response/ArticleWithCommentsResponse.java
@@ -1,4 +1,4 @@
-package com.studyproject.boardproject.response;
+package com.studyproject.boardproject.dto.response;
 
 import com.studyproject.boardproject.dto.ArticleWithCommentsDto;
 

--- a/src/main/java/com/studyproject/boardproject/repository/UserAccountRepository.java
+++ b/src/main/java/com/studyproject/boardproject/repository/UserAccountRepository.java
@@ -3,5 +3,5 @@ package com.studyproject.boardproject.repository;
 import com.studyproject.boardproject.domain.UserAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserAccountRepository extends JpaRepository<UserAccount, Long> {
+public interface UserAccountRepository extends JpaRepository<UserAccount, String> {
 }

--- a/src/main/java/com/studyproject/boardproject/service/ArticleService.java
+++ b/src/main/java/com/studyproject/boardproject/service/ArticleService.java
@@ -1,10 +1,12 @@
 package com.studyproject.boardproject.service;
 
 import com.studyproject.boardproject.domain.Article;
-import com.studyproject.boardproject.domain.type.SearchType;
+import com.studyproject.boardproject.domain.UserAccount;
+import com.studyproject.boardproject.domain.constant.SearchType;
 import com.studyproject.boardproject.dto.ArticleDto;
 import com.studyproject.boardproject.dto.ArticleWithCommentsDto;
 import com.studyproject.boardproject.repository.ArticleRepository;
+import com.studyproject.boardproject.repository.UserAccountRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +24,7 @@ import java.util.List;
 public class ArticleService {
 
     private final ArticleRepository articleRepository;
+    private final UserAccountRepository userAccountRepository;
 
     @Transactional(readOnly = true)
     public Page<ArticleDto> searchArticles(SearchType searchType, String searchKeyword, Pageable pageable) {
@@ -39,19 +42,27 @@ public class ArticleService {
     }
 
     @Transactional(readOnly = true)
-    public ArticleWithCommentsDto getArticle(Long articleId) {
+    public ArticleWithCommentsDto getArticleWithComments(Long articleId) {
         return articleRepository.findById(articleId)
                 .map(ArticleWithCommentsDto::from)
                 .orElseThrow(() -> new EntityNotFoundException("게시글이 없습니다. - articleId: " + articleId));
     }
 
-    public void saveArticle(ArticleDto dto) {
-        articleRepository.save(dto.toEntity());
+    @Transactional(readOnly = true)
+    public ArticleDto getArticle(Long articleId) {
+        return articleRepository.findById(articleId)
+                .map(ArticleDto::from)
+                .orElseThrow(() -> new EntityNotFoundException("게시글이 없습니다. - articleId: " + articleId));
     }
 
-    public void updateArticle(ArticleDto dto) {
+    public void saveArticle(ArticleDto dto) {
+        UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
+        articleRepository.save(dto.toEntity(userAccount));
+    }
+
+    public void updateArticle(Long articleId, ArticleDto dto) {
         try {
-            Article article = articleRepository.getReferenceById(dto.id());
+            Article article = articleRepository.getReferenceById(articleId);
             if (dto.title() != null) article.setTitle(dto.title());
             if (dto.content() != null) article.setContent(dto.content());
             article.setHashtag(dto.hashtag());
@@ -67,7 +78,7 @@ public class ArticleService {
         articleRepository.deleteById(articleId);
     }
 
-    public Long getArticleCount() {
+    public long getArticleCount() {
         return articleRepository.count();
     }
 

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -25,7 +25,7 @@
 
         <!-- side menu -->
         <div class="row g-5">
-            <section class="col-md-5 col-lg-4 order-md-last">
+            <section class="col-md-3 col-lg-4 order-md-last">
                 <aside>
                     <p><span id="nickname">Hyeon</span></p>
                     <p><a id="email" rel="me" href="mailto:mrk19967@gmail.com">hyeon@mail.com</a></p>
@@ -34,28 +34,37 @@
                 </aside>
             </section>
 
-            <article id="article-content" class="col-md-7 col-lg-8">
-                <pre>본문<br><br></pre>
+            <article id="article-content" class="col-md-9 col-lg-8">
+                <pre>본문</pre>
             </article>
+        </div>
+        <!-- 수정 삭제 버튼 -->
+        <div class="row g-5" id="article-buttons">
+            <form id="delete-article-form">
+                <div class="pb-5 d-grid gap-2 d-md-block">
+                    <a class="btn btn-success me-md-2" role="button" id="update-article">수정</a>
+                    <button class="btn btn-danger me-md-2" type="submit">삭제</button>
+                </div>
+            </form>
         </div>
 
         <!-- comments -->
         <div class="row g-5">
             <section>
                 <form class="row g-3">
-                    <div class="col-8">
+                    <div class="col-md-9 col-lg-8">
                         <label for="comment-textbox" hidden>댓글</label>
                         <textarea class="form-control" id="comment-textbox" placeholder="댓글 쓰기.." rows="3"></textarea>
                     </div>
-                    <div class="col-auto">
+                    <div class="col-md-3 col-lg-4">
                         <label for="comment-submit" hidden>댓글 쓰기</label>
                         <button class="btn btn-primary" id="comment-submit" type="submit">쓰기</button>
                     </div>
                 </form>
 
-                <ul id="article-comments" class="row col-7">
+                <ul id="article-comments" class="row col-md-10 col-lg-8 pt-3">
                     <li>
-                        <div>
+                        <div class="row">
                             <strong>Hyeon</strong>
                             <small><time>2024-01-18</time></small>
                             <p>
@@ -66,8 +75,8 @@
                         </div>
                     </li>
                     <li>
-                        <div>
-                            <strong>Hyeon</strong>
+                        <div class="row">
+                            <strong>Hyeon2</strong>
                             <small><time>2024-01-18</time></small>
                             <p>
                                 test article Comments content....

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -12,6 +12,12 @@
         <attr sel="#article-content/pre" th:text="*{content}" />
     </attr>
 
+    <attr sel="#article-buttons">
+        <attr sel="#delete-article-form" th:action="'/articles/' + *{id} + '/delete'" th:method="post">
+            <attr sel="#update-article" th:href="'/articles/' + *{id} + '/form'" />
+        </attr>
+    </attr>
+
     <attr sel="#article-comments" th:remove="all-but-first">
         <attr sel="li[0]" th:each="articleComment : ${articleComments}">
             <attr sel="div/strong" th:text="${articleComment.nickname}" />

--- a/src/main/resources/templates/articles/index.html
+++ b/src/main/resources/templates/articles/index.html
@@ -23,7 +23,7 @@
         <div class="row">
             <div class="card card-margin search-form">
                 <div class="card-body p-0">
-                    <form action="/articles" method="GET">
+                    <form id="search-form">
                         <div class="row">
                             <div class="col-12">
                                 <div class="row no-gutters">
@@ -56,36 +56,45 @@
                 </div>
             </div>
         </div>
-        <table class="table" id="article-table">
-            <thead>
-                <tr>
-                    <th class="title col-6"><a>제목</a></th>
-                    <th class="hashtag col-2"><a>해시태그</a></th>
-                    <th class="user-id col"><a>작성자</a></th>
-                    <th class="created-at col"><a>작성일</a></th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td class="title"><a>첫글</a></td>
-                    <td class="hashtag">#Java</td>
-                    <td class="user-id">Hyeon</td>
-                    <td class="created-at"><time>2024-01-17</time></td>
-                </tr>
-                <tr>
-                    <td>두번째글</td>
-                    <td>Spring</td>
-                    <td>Hyeon</td>
-                    <td>2024-01-16</td>
-                </tr>
-                <tr>
-                    <td>세번째글</td>
-                    <td>Python</td>
-                    <td>Hyeon</td>
-                    <td>2024-01-15</td>
-                </tr>
-            </tbody>
-        </table>
+
+        <div class="row">
+            <table class="table" id="article-table">
+                <thead>
+                    <tr>
+                        <th class="title col-6"><a>제목</a></th>
+                        <th class="hashtag col-2"><a>해시태그</a></th>
+                        <th class="user-id"><a>작성자</a></th>
+                        <th class="created-at"><a>작성일</a></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="title"><a>첫글</a></td>
+                        <td class="hashtag">#Java</td>
+                        <td class="user-id">Hyeon</td>
+                        <td class="created-at"><time>2024-01-17</time></td>
+                    </tr>
+                    <tr>
+                        <td>두번째글</td>
+                        <td>Spring</td>
+                        <td>Hyeon</td>
+                        <td>2024-01-16</td>
+                    </tr>
+                    <tr>
+                        <td>세번째글</td>
+                        <td>Python</td>
+                        <td>Hyeon</td>
+                        <td>2024-01-15</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div class="row">
+            <div class="d-grid gap-2 d-md-flex justify-content-md-end">
+                <a class="btn btn-primary me-md-2" role="button" id="write-article">글쓰기</a>
+            </div>
+        </div>
 
         <nav id="pagination" aria-label="Page navigation example">
             <ul class="pagination justify-content-center">

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -4,6 +4,7 @@
     <attr sel="#footer" th:replace="footer :: footer"/>
 
     <attr sel="main" th:object="${articles}">
+        <attr sel="#search-form" th:action="@{/articles}" th:method="GET" />
         <attr sel="#search-type" th:remove="all-but-first">
             <attr sel="option[0]"
                   th:each="searchType : ${searchTypes}"
@@ -51,6 +52,9 @@
                 </attr>
             </attr>
         </attr>
+
+        <attr sel="#write-article" th:href="@{/articles/form}" />
+
         <attr sel="#pagination">
             <attr sel="li[0]/a"
                   th:text="'previous'"

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -9,7 +9,8 @@
         <div class="container">
             <div class="d-flex flex-wrap align-items-center justify-content-center justify-content-lg-start">
                 <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
-                    <li><a href="/" class="nav-link px-2 text-secondary">Home</a></li>
+                    <li><a id="home" href="#" class="nav-link px-2 text-secondary">Home</a></li>
+                    <li><a id="hashtag" href="#" class="nav-link px-2 text-secondary">Hashtag</a></li>
                 </ul>
 
                 <div class="text-end">

--- a/src/main/resources/templates/header.th.xml
+++ b/src/main/resources/templates/header.th.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#home" th:href="@{/}" />
+    <attr sel="#hashtag" th:href="@{/articles/search-hashtag}" />
+</thlogic>

--- a/src/test/java/com/studyproject/boardproject/controller/ArticleControllerTest.java
+++ b/src/test/java/com/studyproject/boardproject/controller/ArticleControllerTest.java
@@ -1,11 +1,16 @@
 package com.studyproject.boardproject.controller;
 
 import com.studyproject.boardproject.config.SecurityConfig;
-import com.studyproject.boardproject.domain.type.SearchType;
+import com.studyproject.boardproject.domain.constant.FormStatus;
+import com.studyproject.boardproject.domain.constant.SearchType;
+import com.studyproject.boardproject.dto.ArticleDto;
 import com.studyproject.boardproject.dto.ArticleWithCommentsDto;
 import com.studyproject.boardproject.dto.UserAccountDto;
+import com.studyproject.boardproject.dto.request.ArticleRequest;
+import com.studyproject.boardproject.dto.response.ArticleResponse;
 import com.studyproject.boardproject.service.ArticleService;
 import com.studyproject.boardproject.service.PaginationService;
+import com.studyproject.boardproject.util.FormDataEncoder;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,21 +30,24 @@ import java.util.List;
 import java.util.Set;
 
 import static org.mockito.BDDMockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("View Controller - 게시글")
-@Import(SecurityConfig.class)
+@Import({SecurityConfig.class, FormDataEncoder.class})
 @WebMvcTest(ArticleController.class)
 class ArticleControllerTest {
 
     private final MockMvc mvc;
+    private final FormDataEncoder formDataEncoder;
 
     @MockBean private ArticleService articleService;
     @MockBean private PaginationService paginationService;
 
-    public ArticleControllerTest(@Autowired MockMvc mvc) {
+    public ArticleControllerTest(@Autowired MockMvc mvc, @Autowired FormDataEncoder formDataEncoder) {
         this.mvc = mvc;
+        this.formDataEncoder = formDataEncoder;
     }
 
     @DisplayName("[View/GET] 게시글 리스트 (게시판) 페이지 - 정상 호출 ")
@@ -115,22 +123,26 @@ class ArticleControllerTest {
         then(paginationService).should().getPaginationBarNumbers(pageable.getPageNumber(), Page.empty().getTotalPages());
     }
 
-    @DisplayName("[View/GET] 게시글 상세 페이지 - 정상 호출 ")
+    @DisplayName("[View/GET] 게시글 페이지 - 정상 호출 ")
     @Test
     public void givenNothing_whenRequestingArticleView_thenReturnsArticleView() throws Exception {
         // Given
         Long articleId = 1L;
-        given(articleService.getArticle(articleId)).willReturn(createArticleWithCommentsDto());
+        long totalCount = 1L;
+        given(articleService.getArticleWithComments(articleId)).willReturn(createArticleWithCommentsDto());
+        given(articleService.getArticleCount()).willReturn(totalCount);
 
-        // When&Then
+        // When & Then
         mvc.perform(get("/articles/" + articleId))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("articles/detail"))
                 .andExpect(model().attributeExists("article"))
-                .andExpect(model().attributeExists("articleComments"));
+                .andExpect(model().attributeExists("articleComments"))
+                .andExpect(model().attribute("totalCount", totalCount));
 
-        then(articleService).should().getArticle(articleId);
+        then(articleService).should().getArticleWithComments(articleId);
+        then(articleService).should().getArticleCount();
     }
 
     @Disabled("구현중")
@@ -198,7 +210,108 @@ class ArticleControllerTest {
         then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
     }
 
+    @DisplayName("[View/GET] 새 게시글 작성 페이지")
+    @Test
+    void givenNothing_whenRequesting_thenReturnsNewArticlePage() throws Exception{
+        // Given
+
+        // When&Then
+        mvc.perform(get("/articles/form"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("articles/form"))
+                .andExpect(model().attribute("formStatus", FormStatus.CREATE));
+    }
+
+    @DisplayName("[View/POST] 새 게시글 등록 - 정상 호출")
+    @Test
+    void givenArticleInfo_whenRequesting_thenSaveNewArticles() throws Exception{
+        // Given
+        ArticleRequest articleRequest = ArticleRequest.of("new title", "new content", "#new");
+        willDoNothing().given(articleService).saveArticle(any(ArticleDto.class));
+
+        // When&Then
+        mvc.perform(
+                post("/articles/form")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .content(formDataEncoder.encode(articleRequest))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(view().name("redirect:/articles"))
+                .andExpect(redirectedUrl("/articles"));
+
+        then(articleService).should().saveArticle(any(ArticleDto.class));
+    }
+
+    @DisplayName("[View/GET] 게시글 수정 페이지")
+    @Test
+    void givenNothing_whenRequesting_thenReturnsUpdatedArticlePage() throws Exception{
+        // Given
+        long articleId = 1L;
+        ArticleDto dto = createArticleDto();
+        given(articleService.getArticle(articleId)).willReturn(dto);
+
+        // When&Then
+        mvc.perform(get("/articles/" + articleId + "/form"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("articles/form"))
+                .andExpect(model().attribute("article", ArticleResponse.from(dto)))
+                .andExpect(model().attribute("formStatus", FormStatus.UPDATE));
+
+        then(articleService).should().getArticle(articleId);
+    }
+
+    @DisplayName("[View/POST] 게시글 수정 - 정상 호출")
+    @Test
+    void givenUpdateArticleInfo_whenRequesting_thenUpdatesNewArticles() throws Exception{
+        // Given
+        long articleId = 1L;
+        ArticleRequest articleRequest = ArticleRequest.of("new title", "new content", "#new");
+        willDoNothing().given(articleService).updateArticle(eq(articleId), any(ArticleDto.class));
+
+        // When&Then
+        mvc.perform(
+                        post("/articles/" + articleId + "/form")
+                                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                                .content(formDataEncoder.encode(articleRequest))
+                                .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(view().name("redirect:/articles/" + articleId))
+                .andExpect(redirectedUrl("/articles/" + articleId));
+
+        then(articleService).should().updateArticle(eq(articleId), any(ArticleDto.class));
+    }
+
+    @DisplayName("[View/POST] 게시글 삭제 - 정상 호출")
+    @Test
+    void givenArticleIdToDelete_whenRequesting_thenDeleteswArticles() throws Exception{
+        // Given
+        long articleId = 1L;
+        willDoNothing().given(articleService).deleteArticle(articleId);
+
+        // When&Then
+        mvc.perform(
+                        post("/articles/" + articleId + "/delete")
+                                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                                .with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/articles"))
+                .andExpect(redirectedUrl("/articles"));
+
+        then(articleService).should().deleteArticle(articleId);
+    }
+
     // fixfure
+    private ArticleDto createArticleDto() {
+        return ArticleDto.of(
+                createUserAccountDto(),
+                "title",
+                "content",
+                "#java"
+        );
+    }
+
     private ArticleWithCommentsDto createArticleWithCommentsDto() {
         return ArticleWithCommentsDto.of(
                 1L,
@@ -208,15 +321,14 @@ class ArticleControllerTest {
                 "content",
                 "#java",
                 LocalDateTime.now(),
-                "Hyeon",
+                "hyeon",
                 LocalDateTime.now(),
-                "Hyeon"
+                "hyeon"
         );
     }
 
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
-                1L,
                 "hyeon",
                 "dummy",
                 "hyeon@email.com",

--- a/src/test/java/com/studyproject/boardproject/service/ArticleServiceTest.java
+++ b/src/test/java/com/studyproject/boardproject/service/ArticleServiceTest.java
@@ -2,11 +2,12 @@ package com.studyproject.boardproject.service;
 
 import com.studyproject.boardproject.domain.Article;
 import com.studyproject.boardproject.domain.UserAccount;
-import com.studyproject.boardproject.domain.type.SearchType;
+import com.studyproject.boardproject.domain.constant.SearchType;
 import com.studyproject.boardproject.dto.ArticleDto;
 import com.studyproject.boardproject.dto.ArticleWithCommentsDto;
 import com.studyproject.boardproject.dto.UserAccountDto;
 import com.studyproject.boardproject.repository.ArticleRepository;
+import com.studyproject.boardproject.repository.UserAccountRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -31,6 +33,7 @@ class ArticleServiceTest {
 
     @InjectMocks private ArticleService sut; // system under test -> 시스템 테스트의 대상이다
     @Mock private ArticleRepository articleRepository;
+    @Mock private UserAccountRepository userAccountRepository;
 
     @DisplayName("검색어 없이 게시글을 검색하면, 게시글 페이지를 반환한다.")
     @Test
@@ -94,16 +97,16 @@ class ArticleServiceTest {
         then(articleRepository).should().findByHashtag(hashtag, pageable);
     }
 
-    @DisplayName("게시글을 조회하면, 게시글을 반환한다.")
+    @DisplayName("게시글 ID로 조회하면, 댓글이 담긴 게시글을 반환한다.")
     @Test
-    void givenArticleId_whenSearchingArticle_thenReturnsArticle() {
+    void givenArticleId_whenSearchingArticleWithComments_thenReturnsArticleWithComments() {
         // Given
         Long articleId = 1L;
         Article article = createArticle();
         given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
 
         // When
-        ArticleWithCommentsDto dto = sut.getArticle(articleId);
+        ArticleWithCommentsDto dto = sut.getArticleWithComments(articleId);
 
         // Then
         assertThat(dto)
@@ -114,7 +117,43 @@ class ArticleServiceTest {
         then(articleRepository).should().findById(articleId);
     }
 
-    @DisplayName("없는 게시물을 조회하면, 예외를 던진다.")
+    @DisplayName("댓글 달린 게시글이 없으면, 예외를 던진다.")
+    @Test
+    void givenNonexistentArticleId_whenSearchingArticleWithComments_thenThrowsException() {
+        // Given
+        Long articleId = 0L;
+        given(articleRepository.findById(articleId)).willReturn(Optional.empty());
+
+        // When
+        Throwable t = catchThrowable(() -> sut.getArticleWithComments(articleId));
+
+        // Then
+        assertThat(t)
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("게시글이 없습니다. - articleId: " + articleId);
+        then(articleRepository).should().findById(articleId);
+    }
+
+    @DisplayName("게시글을 조회하면, 게시글을 반환한다.")
+    @Test
+    void givenArticleId_whenSearchingArticle_thenReturnsArticle() {
+        // Given
+        Long articleId = 1L;
+        Article article = createArticle();
+        given(articleRepository.findById(articleId)).willReturn(Optional.of(article));
+
+        // When
+        ArticleDto dto = sut.getArticle(articleId);
+
+        // Then
+        assertThat(dto)
+                .hasFieldOrPropertyWithValue("title", article.getTitle())
+                .hasFieldOrPropertyWithValue("content", article.getContent())
+                .hasFieldOrPropertyWithValue("hashtag", article.getHashtag());
+        then(articleRepository).should().findById(articleId);
+    }
+
+    @DisplayName("게시글이 없으면, 예외를 던진다.")
     @Test
     void givenNoneexistentArticleId_whenSearchingArticle_thenThrowExeption() {
         // Given
@@ -139,12 +178,14 @@ class ArticleServiceTest {
         ArticleDto dto = createArticleDto();
         // 내부적으로 articleRepository에서 save method가 호출될 것이라는 것을 보여줌
         // 여기서 다른 검사를 하지 않는한 크게 의미있는 코드는 아니다.
+        given(userAccountRepository.getReferenceById(dto.userAccountDto().userId())).willReturn(createUserAccount());
         given(articleRepository.save(any(Article.class))).willReturn(null);
 
         // When
         sut.saveArticle(dto);
 
         // Then
+        then(userAccountRepository).should().getReferenceById(dto.userAccountDto().userId());
         then(articleRepository).should().save(any(Article.class)); // save를 한번 호출 했는가 검사
 
     }
@@ -158,7 +199,7 @@ class ArticleServiceTest {
         given(articleRepository.getReferenceById(dto.id())).willReturn(article);
 
         // When
-        sut.updateArticle(dto);
+        sut.updateArticle(dto.id(), dto);
 
         // Then
         assertThat(article)
@@ -178,7 +219,7 @@ class ArticleServiceTest {
         given(articleRepository.getReferenceById(dto.id())).willThrow(EntityNotFoundException.class);
 
         // When
-        sut.updateArticle(dto);
+        sut.updateArticle(dto.id(), dto);
 
         // Then
         then(articleRepository).should().getReferenceById(dto.id());
@@ -244,12 +285,15 @@ class ArticleServiceTest {
     }
 
     private Article createArticle() {
-        return Article.of(
+        Article article = Article.of(
                 createUserAccount(),
                 "title",
                 "content",
                 "#java"
         );
+        ReflectionTestUtils.setField(article, "id", 1L);
+
+        return article;
     }
 
     private ArticleDto createArticleDto() {
@@ -272,7 +316,6 @@ class ArticleServiceTest {
 
     private UserAccountDto createUserAccountDto() {
         return UserAccountDto.of(
-                1L,
                 "hyeon",
                 "dummy",
                 "hyeon@email.com",

--- a/src/test/java/com/studyproject/boardproject/util/FormDataEncoder.java
+++ b/src/test/java/com/studyproject/boardproject/util/FormDataEncoder.java
@@ -1,0 +1,32 @@
+package com.studyproject.boardproject.util;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Map;
+
+@TestComponent
+public class FormDataEncoder {
+
+    private final ObjectMapper mapper;
+
+    public FormDataEncoder(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public String encode(Object obj) {
+        Map<String, String> fieldMap = mapper.convertValue(obj, new TypeReference<>() {});
+        MultiValueMap<String, String> valueMap = new LinkedMultiValueMap<>();
+        valueMap.setAll(fieldMap);
+
+        return UriComponentsBuilder.newInstance()
+                .queryParams(valueMap)
+                .encode()
+                .build()
+                .getQuery();
+    }
+}

--- a/src/test/java/com/studyproject/boardproject/util/FormDataEncoderTest.java
+++ b/src/test/java/com/studyproject/boardproject/util/FormDataEncoderTest.java
@@ -1,0 +1,77 @@
+package com.studyproject.boardproject.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("테스트 도구 - Form 데이터 인코더")
+@Import({FormDataEncoder.class, ObjectMapper.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = FormDataEncoderTest.class)
+class FormDataEncoderTest {
+
+    private final FormDataEncoder formDataEncoder;
+
+    public FormDataEncoderTest(@Autowired FormDataEncoder formDataEncoder) {
+        this.formDataEncoder = formDataEncoder;
+    }
+
+    @DisplayName("객체를 넣으면, url encoding 된 form body data 형식의 문자열을 돌려준다.")
+    @Test
+    void givenObject_whenEncoding_thenReturnsFormEncodedString() {
+        // Given
+        TestObject obj = new TestObject(
+                "This 'is' \"test\" string.",
+                List.of("hello", "my", "friend").toString().replace(" ", ""),
+                String.join(",", "hello", "my", "friend"),
+                null,
+                1234,
+                3.14,
+                false,
+                BigDecimal.TEN,
+                TestEnum.THREE
+        );
+
+        // When
+        String result = formDataEncoder.encode(obj);
+
+        System.out.println(result);
+
+        // Then
+        assertThat(result).isEqualTo(
+                "str=This%20'is'%20%22test%22%20string." +
+                        "&listStr1=%5Bhello,my,friend%5D" +
+                        "&listStr2=hello,my,friend" +
+                        "&nullStr" +
+                        "&number=1234" +
+                        "&floatingNumber=3.14" +
+                        "&bool=false" +
+                        "&bigDecimal=10" +
+                        "&testEnum=THREE"
+        );
+    }
+
+    record TestObject(
+            String str,
+            String listStr1,
+            String listStr2,
+            String nullStr,
+            Integer number,
+            Double floatingNumber,
+            Boolean bool,
+            BigDecimal bigDecimal,
+            TestEnum testEnum
+    ) {}
+
+    enum TestEnum {
+        ONE, TWO, THREE
+    }
+
+}


### PR DESCRIPTION
* 해더에 해시태그 메뉴 추가
* spring security test 디펜던시 추가
* 게시판, 게시글 뷰에 글쓰기, 수정, 삭제 버튼 추가
* dto에 필요없는 부분 제거 및 생성일, 생성자 등 자동으로 입력이 되는 부분을 제외하여 입력하는 생성자 메소드 추가
* controller에서 사용될 ArticleRequest와 ArticleCommentRequest DTO를 생성
* <form> 데이터를 테스트 하기 위한 인코더 추가(test 파일 내의)
* update와 create를 구분하기 위한 enum파일 추가
* UserAccount의 id는 primart key인 String으로 들어가기 때문에 해당 부분 수정
* 도메인 관련 request, response dto를 domain 패키지 안으로 이동
* Article관련 테스트에서 도메인등 변경된 내용에 따른 문제 해결을 위한 수정
* Article CRUD관련 테스트 추가 작성
* ArticleService에 Article과 ArticleWithComment로 나눠서 비지니스로직 재작성 및 도메인 내용 변경에 따른 수정
* ArticleController에 CRUC관련 mapping 및 ArticleService에서 기능을 열결