### PR TITLE
시큐리티 설정과 자바 대응 코드 구현 및 테스트 수정 및 구현

### DIFF
--- a/src/main/java/com/studyproject/boardproject/config/JpaConfig.java
+++ b/src/main/java/com/studyproject/boardproject/config/JpaConfig.java
@@ -1,9 +1,13 @@
 package com.studyproject.boardproject.config;
 
+import com.studyproject.boardproject.dto.security.BoardPrincipal;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.Optional;
 
@@ -13,7 +17,12 @@ public class JpaConfig {
 
     @Bean
     public AuditorAware<String> auditorAware() {
-        // TODO: 스프링 시큐리티로 인증 기능을 만들때 값을 가져와서 value에 이름 값을 넣어줘야 함
-        return () -> Optional.of("hyeon"); // 수정시 들어가는 이름
+        // SecurityContextHolder -> Security관련 모든 정보를 들고 있음
+        return () -> Optional.ofNullable(SecurityContextHolder.getContext())
+                .map(SecurityContext::getAuthentication) // 인증 정보를 가져옴
+                .filter(Authentication::isAuthenticated)// 인증이 되었는지 확인
+                .map(Authentication::getPrincipal)
+                .map(BoardPrincipal.class::cast)
+                .map(BoardPrincipal::getUsername); // 수정시 들어가는 이름
     }
 }

--- a/src/main/java/com/studyproject/boardproject/config/SecurityConfig.java
+++ b/src/main/java/com/studyproject/boardproject/config/SecurityConfig.java
@@ -1,8 +1,19 @@
 package com.studyproject.boardproject.config;
 
+import com.studyproject.boardproject.domain.UserAccount;
+import com.studyproject.boardproject.dto.UserAccountDto;
+import com.studyproject.boardproject.dto.security.BoardPrincipal;
+import com.studyproject.boardproject.repository.UserAccountRepository;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 import static org.springframework.security.config.Customizer.withDefaults;
@@ -13,8 +24,43 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .authorizeHttpRequests(auth -> auth
+                        // webSecurityCustomizer의 부분을 아래로 옮김
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .requestMatchers(
+                                HttpMethod.GET,
+                                "/",
+                                "/articles",
+                                "/articles/search-hashtag"
+                        ).permitAll() // 위에 선언된 주소만 허용
+                        .anyRequest().authenticated() // 나머지는 인증 적용
+                )
                 .formLogin(withDefaults())
+                .logout(logout -> logout.logoutSuccessUrl("/"))
                 .build();
+    }
+    // 하지만 이렇게 제외하게 되면 공격에 취약한 부분이 생기므로 securityFilterChain여기서 제외하는 것을 권고함
+//    @Bean
+//    public WebSecurityCustomizer webSecurityCustomizer() {
+//        // 여기에 설정한 곳은 아예 스프링 시큐리티 검사에서 제외한다.
+//        // static resource, css, js 같은 파일들
+//        // PathRequest.toStaticResources().atCommonLocations()는 스프링에서 지원하는 static자원 모든 부분을 가리킴
+//        return (web) -> web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+//    }
+
+    @Bean
+    public UserDetailsService userDetailsService(UserAccountRepository userAccountRepository) {
+        return username -> userAccountRepository
+                .findById(username)
+                .map(UserAccountDto::from)
+                .map(BoardPrincipal::from)
+                // optional이므로 오류났을 경우에 행동 지정
+                .orElseThrow(() -> new UsernameNotFoundException(("유저를 찾을 수 없습니다 - username: " + username)));
+    }
+
+    // spring security의 인증을 구현할때 password encoder를 구현해야 합니다.
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 }

--- a/src/main/java/com/studyproject/boardproject/controller/ArticleCommentController.java
+++ b/src/main/java/com/studyproject/boardproject/controller/ArticleCommentController.java
@@ -2,8 +2,10 @@ package com.studyproject.boardproject.controller;
 
 import com.studyproject.boardproject.dto.UserAccountDto;
 import com.studyproject.boardproject.dto.request.ArticleCommentRequest;
+import com.studyproject.boardproject.dto.security.BoardPrincipal;
 import com.studyproject.boardproject.service.ArticleCommentService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,25 +19,22 @@ public class ArticleCommentController {
     private final ArticleCommentService articleCommentService;
 
     @PostMapping("/new")
-    public String postNewArticleComment(ArticleCommentRequest articleCommentRequest) {
-        // TODO: 인증 정보를 넣어줘야 한다.
-        articleCommentService.saveArticleComment(articleCommentRequest.toDto(
-                UserAccountDto.of(
-                        "hyeon",
-                        "dummy",
-                        "hyeon@email.com",
-                        "Hyeon",
-                        "memo"
-                )
-        ));
-
+    public String postNewArticleComment(
+            ArticleCommentRequest articleCommentRequest,
+            @AuthenticationPrincipal BoardPrincipal boardPrincipal
+    ) {
+        articleCommentService.saveArticleComment(articleCommentRequest.toDto(boardPrincipal.toDto()));
 
         return "redirect:/articles/" + articleCommentRequest.articleId();
     }
 
     @PostMapping("/{commentId}/delete")
-    public String deleteArticleComment(@PathVariable Long commentId, Long articleId) {
-        articleCommentService.deleteArticleComment(commentId);
+    public String deleteArticleComment(
+           @PathVariable Long commentId,
+           @AuthenticationPrincipal BoardPrincipal boardPrincipal,
+           Long articleId
+    ) {
+        articleCommentService.deleteArticleComment(commentId, boardPrincipal.username());
 
         return "redirect:/articles/" + articleId;
     }

--- a/src/main/java/com/studyproject/boardproject/controller/ArticleController.java
+++ b/src/main/java/com/studyproject/boardproject/controller/ArticleController.java
@@ -6,6 +6,7 @@ import com.studyproject.boardproject.dto.UserAccountDto;
 import com.studyproject.boardproject.dto.request.ArticleRequest;
 import com.studyproject.boardproject.dto.response.ArticleResponse;
 import com.studyproject.boardproject.dto.response.ArticleWithCommentsResponse;
+import com.studyproject.boardproject.dto.security.BoardPrincipal;
 import com.studyproject.boardproject.service.ArticleService;
 import com.studyproject.boardproject.service.PaginationService;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.*;
@@ -84,11 +86,12 @@ public class ArticleController {
     }
 
     @PostMapping ("/form")
-    public String postNewArticle(ArticleRequest articleRequest) {
+    public String postNewArticle(
+            ArticleRequest articleRequest,
+            @AuthenticationPrincipal BoardPrincipal boardPrincipal
+    ) {
         // TODO: 인증 정보를 넣어줘야 한다.
-        articleService.saveArticle(articleRequest.toDto(UserAccountDto.of(
-                "hyeon", "dummy", "hyeon@mail.com", "Hyeon", "memo"
-        )));
+        articleService.saveArticle(articleRequest.toDto(boardPrincipal.toDto()));
 
         return "redirect:/articles";
     }
@@ -105,19 +108,23 @@ public class ArticleController {
     }
 
     @PostMapping("/{articleId}/form")
-    public String updateArticle(@PathVariable Long articleId, ArticleRequest articleRequest) {
+    public String updateArticle(
+            @PathVariable Long articleId,
+            @AuthenticationPrincipal BoardPrincipal boardPrincipal,
+            ArticleRequest articleRequest
+    ) {
         // TODO: 인증정보를 넣어줘야한다.
-        articleService.updateArticle(articleId, articleRequest.toDto(
-                UserAccountDto.of(
-                        "hyeon", "dummy", "hyeon@mail.com", "Hyeon", "memo"
-                )));
+        articleService.updateArticle(articleId, articleRequest.toDto(boardPrincipal.toDto()));
 
         return "redirect:/articles/" + articleId;
     }
 
     @PostMapping("/{articleId}/delete")
-    public String deleteArticle(@PathVariable Long articleId) {
-        articleService.deleteArticle(articleId);
+    public String deleteArticle(
+            @PathVariable Long articleId,
+            @AuthenticationPrincipal BoardPrincipal boardPrincipal
+        ) {
+        articleService.deleteArticle(articleId, boardPrincipal.username());
 
         return "redirect:/articles";
     }

--- a/src/main/java/com/studyproject/boardproject/dto/security/BoardPrincipal.java
+++ b/src/main/java/com/studyproject/boardproject/dto/security/BoardPrincipal.java
@@ -1,0 +1,79 @@
+package com.studyproject.boardproject.dto.security;
+
+import com.studyproject.boardproject.dto.UserAccountDto;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record BoardPrincipal(
+        String username,
+        String password,
+        Collection<? extends GrantedAuthority> authorities,
+        String email,
+        String nickname,
+        String memo
+) implements UserDetails {
+
+    public static BoardPrincipal of(String username, String password, String email, String nickname, String memo) {
+
+        Set<RoleType> roleTypes = Set.of(RoleType.USER);
+
+        return new BoardPrincipal(
+                username,
+                password,
+                roleTypes.stream()
+                        .map(RoleType::getName)
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toUnmodifiableSet()),
+                email,
+                nickname,
+                memo
+        );
+    }
+
+    public static BoardPrincipal from(UserAccountDto dto) {
+        return BoardPrincipal.of(
+            dto.userId(),
+            dto.userPassword(),
+            dto.email(),
+            dto.nickname(),
+            dto.memo()
+        );
+    }
+
+    public UserAccountDto toDto() {
+        return UserAccountDto.of(
+          username,
+          password,
+          email,
+          nickname,
+          memo
+        );
+    }
+
+    @Override public String getUsername() { return username; }
+    @Override public String getPassword() { return password; }
+
+    @Override public Collection<? extends GrantedAuthority> getAuthorities() { return authorities; }
+
+    // spring security에 어느정도 위임해서 true로 반환한다.
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
+
+    public enum RoleType {
+        USER("ROLE_USER");
+
+        @Getter private final String name;
+
+        RoleType(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/src/main/java/com/studyproject/boardproject/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/studyproject/boardproject/repository/ArticleCommentRepository.java
@@ -20,6 +20,8 @@ public interface ArticleCommentRepository extends
 
     List<ArticleComment> findByArticle_Id(Long articleId);
 
+    void deleteByIdAndUserAccount_UserId(Long articleId, String userId);
+
     @Override
     default void customize(QuerydslBindings bindings, QArticleComment root) {
         bindings.excludeUnlistedProperties(true);

--- a/src/main/java/com/studyproject/boardproject/repository/ArticleRepository.java
+++ b/src/main/java/com/studyproject/boardproject/repository/ArticleRepository.java
@@ -27,6 +27,8 @@ public interface ArticleRepository extends
     Page<Article> findByUserAccount_NicknameContaining(String nickname, Pageable pageable);
     Page<Article> findByHashtag(String hashtag, Pageable pageable);
 
+    void deleteByIdAndUserAccount_userId(Long articleId, String userId);
+
     @Override
     default void customize(QuerydslBindings bindings, QArticle root) {
         // 리스팅하지 않는 프로퍼티를 제외시키는 것

--- a/src/main/java/com/studyproject/boardproject/service/ArticleCommentService.java
+++ b/src/main/java/com/studyproject/boardproject/service/ArticleCommentService.java
@@ -54,7 +54,7 @@ public class ArticleCommentService {
         }
     }
 
-    public void deleteArticleComment(Long articleCommentId) {
-        articleCommentRepository.deleteById(articleCommentId);
+    public void deleteArticleComment(Long articleCommentId, String userId) {
+        articleCommentRepository.deleteByIdAndUserAccount_UserId(articleCommentId, userId);
     }
 }

--- a/src/main/java/com/studyproject/boardproject/service/ArticleService.java
+++ b/src/main/java/com/studyproject/boardproject/service/ArticleService.java
@@ -63,19 +63,23 @@ public class ArticleService {
     public void updateArticle(Long articleId, ArticleDto dto) {
         try {
             Article article = articleRepository.getReferenceById(articleId);
-            if (dto.title() != null) article.setTitle(dto.title());
-            if (dto.content() != null) article.setContent(dto.content());
-            article.setHashtag(dto.hashtag());
+            UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
+
+            if(article.getUserAccount().equals(userAccount)) {
+                if (dto.title() != null) article.setTitle(dto.title());
+                if (dto.content() != null) article.setContent(dto.content());
+                article.setHashtag(dto.hashtag());
+            }
             // class level transactional에 의해 묶여있어서 트랜잭션이 끝날때 article이 변경된것을 감지하고
             // 쿼리를 날립니다. -> save코드를 따로 쓸 필요가 없다.
         } catch (EntityNotFoundException e) {
-            log.warn("게시글 업데아트 실패. 게시글을 찾을 수 없습니다. - dto: {}", dto);
+            log.warn("게시글 업데아트 실패. 게시글을 수정하는데 필요한 정보를 찾을 수 없습니다. - {}", e.getLocalizedMessage());
         }
 
     }
 
-    public void deleteArticle(long articleId) {
-        articleRepository.deleteById(articleId);
+    public void deleteArticle(long articleId, String userId) {
+        articleRepository.deleteByIdAndUserAccount_userId(articleId, userId);
     }
 
     public long getArticleCount() {

--- a/src/test/java/com/studyproject/boardproject/config/TestSecurityConfig.java
+++ b/src/test/java/com/studyproject/boardproject/config/TestSecurityConfig.java
@@ -1,0 +1,29 @@
+package com.studyproject.boardproject.config;
+
+import com.studyproject.boardproject.domain.UserAccount;
+import com.studyproject.boardproject.repository.UserAccountRepository;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.event.annotation.BeforeTestMethod;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+
+@Import(SecurityConfig.class)
+public class TestSecurityConfig {
+
+    @MockBean private UserAccountRepository userAccountRepository;
+
+    @BeforeTestMethod // 각 테스트 메소드가 실행되지 직전에 실행
+    public void securitySetUp() {
+        given(userAccountRepository.findById(anyString())).willReturn(Optional.of(UserAccount.of(
+            "hyeonTest",
+                "dummy",
+                "hyeon-test@email.com",
+                "HyeonTest",
+                "test memo"
+        )));
+    }
+}

--- a/src/test/java/com/studyproject/boardproject/controller/ArticleCommentControllerTest.java
+++ b/src/test/java/com/studyproject/boardproject/controller/ArticleCommentControllerTest.java
@@ -1,6 +1,7 @@
 package com.studyproject.boardproject.controller;
 
 import com.studyproject.boardproject.config.SecurityConfig;
+import com.studyproject.boardproject.config.TestSecurityConfig;
 import com.studyproject.boardproject.dto.ArticleCommentDto;
 import com.studyproject.boardproject.dto.request.ArticleCommentRequest;
 import com.studyproject.boardproject.service.ArticleCommentService;
@@ -12,6 +13,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Map;
@@ -22,7 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("View Controller - 댓글")
-@Import({SecurityConfig.class, FormDataEncoder.class})
+@Import({TestSecurityConfig.class, FormDataEncoder.class})
 @WebMvcTest(ArticleCommentController.class)
 class ArticleCommentControllerTest {
 
@@ -38,6 +41,7 @@ class ArticleCommentControllerTest {
     }
 
     @DisplayName("[view/POST] 댓글 등록 - 정상 호출")
+    @WithUserDetails(value = "hyeonTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @Test
     void givenArticleCommentInfo_whenRequesting_thenSavesNewArticleComment() throws Exception {
         // Given
@@ -59,12 +63,14 @@ class ArticleCommentControllerTest {
     }
 
     @DisplayName("[view/POST] 댓글 삭제 - 정상 호출")
+    @WithUserDetails(value = "hyeonTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @Test
     void givenArticleCommentIdToDelete_whenRequesting_thenDeletesArticleComment() throws Exception {
         // Given
         long articleId = 1L;
         long articleCommentId = 1L;
-        willDoNothing().given(articleCommentService).deleteArticleComment(articleCommentId);
+        String userId = "hyeonTest";
+        willDoNothing().given(articleCommentService).deleteArticleComment(articleCommentId, userId);
 
         // When&Then
         mvc.perform(
@@ -76,6 +82,6 @@ class ArticleCommentControllerTest {
                 .andExpect(view().name("redirect:/articles/" + articleId))
                 .andExpect(redirectedUrl("/articles/" + articleId));
 
-        then(articleCommentService).should().deleteArticleComment(articleCommentId);
+        then(articleCommentService).should().deleteArticleComment(articleCommentId, userId);
     }
 }

--- a/src/test/java/com/studyproject/boardproject/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/studyproject/boardproject/repository/JpaRepositoryTest.java
@@ -7,14 +7,19 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 
 @DisplayName("JPA 연결 테스트")
-@Import(JpaConfig.class)
+@Import(JpaRepositoryTest.TestJpaConfig.class)
 @DataJpaTest
 class JpaRepositoryTest {
 
@@ -95,4 +100,15 @@ class JpaRepositoryTest {
         assertThat(articleRepository.count()).isEqualTo(previousArticleCount - 1);
         assertThat(articleCommentRepository.count()).isEqualTo(previousArticleCommentCount - deleteCommentsSize);
     }
+
+    @EnableJpaAuditing
+    @TestConfiguration // 테스트의 경우에만 스캐닝되어서 사용 -> JpaConfig부분을 치환함
+    public static class TestJpaConfig {
+
+        @Bean
+        public AuditorAware<String> auditorAware() {
+            return () -> Optional.of("hyeon");
+        }
+    }
+
 }

--- a/src/test/java/com/studyproject/boardproject/service/ArticleCommentServiceTest.java
+++ b/src/test/java/com/studyproject/boardproject/service/ArticleCommentServiceTest.java
@@ -125,13 +125,14 @@ class ArticleCommentServiceTest {
     void givenArticleCommentId_whenDeletingArticleComment_thenDeletesArticleComment() {
         // Given
         Long articleCommentId = 1L;
-        willDoNothing().given(articleCommentRepository).deleteById(articleCommentId);
+        String userId = "hyeon";
+        willDoNothing().given(articleCommentRepository).deleteByIdAndUserAccount_UserId(articleCommentId, userId);
 
         // When
-        sut.deleteArticleComment(articleCommentId);
+        sut.deleteArticleComment(articleCommentId, userId);
 
         // Then
-        then(articleCommentRepository).should().deleteById(articleCommentId);
+        then(articleCommentRepository).should().deleteByIdAndUserAccount_UserId(articleCommentId, userId);
     }
 
     // fixture 작성

--- a/src/test/java/com/studyproject/boardproject/service/ArticleServiceTest.java
+++ b/src/test/java/com/studyproject/boardproject/service/ArticleServiceTest.java
@@ -197,6 +197,7 @@ class ArticleServiceTest {
         Article article = createArticle();
         ArticleDto dto = createArticleDto("새 타이틀", "새 내용", "#Spring");
         given(articleRepository.getReferenceById(dto.id())).willReturn(article);
+        given(userAccountRepository.getReferenceById(dto.userAccountDto().userId())).willReturn(dto.userAccountDto().toEntity());
 
         // When
         sut.updateArticle(dto.id(), dto);
@@ -207,7 +208,8 @@ class ArticleServiceTest {
                 .hasFieldOrPropertyWithValue("content", dto.content())
                 .hasFieldOrPropertyWithValue("hashtag", dto.hashtag());
 
-        then(articleRepository).should().getReferenceById(dto.id()); // save를 한번 호출 했는가 검사
+        then(articleRepository).should().getReferenceById(dto.id());
+        then(userAccountRepository).should().getReferenceById(dto.userAccountDto().userId());
 
     }
 
@@ -231,13 +233,14 @@ class ArticleServiceTest {
     void givenArticleId_whenDeletingArticle_thenDeletesArticle() {
         // Given
         Long articleId = 1L;
-        willDoNothing().given(articleRepository).deleteById(articleId);
+        String userId = "hyeon";
+        willDoNothing().given(articleRepository).deleteByIdAndUserAccount_userId(articleId, userId);
 
         // When
-        sut.deleteArticle(1L);
+        sut.deleteArticle(articleId, userId);
 
         // Then
-        then(articleRepository).should().deleteById(articleId); // save를 한번 호출 했는가 검사
+        then(articleRepository).should().deleteByIdAndUserAccount_userId(articleId, userId);
 
     }
 


### PR DESCRIPTION
* SecurityConfig와 JpaConfig 설정
* Article과 ArticleComment의 테스트 수정 및 구현
* BoardPrincipal 구현
* 게시글과 댓글의 Repository에서 delete사 useraccount에서 userid도 같이 확인하도록 메서드 구현
* Service에서 Repository에서 만든 delete 메서드를 사용하도록 수정
* Controller에서 인증 정보가 필요한 곳에서 받을 수 있도록 수정 및 해당 정보를 이용한 로직 수정
* Test전용 SecuritySetUp 생성