### PR TITLE
Develop

### DIFF
--- a/src/main/java/com/studyproject/boardproject/controller/ArticleController.java
+++ b/src/main/java/com/studyproject/boardproject/controller/ArticleController.java
@@ -43,6 +43,7 @@ public class ArticleController {
         map.addAttribute("articles",articles);
         map.addAttribute("paginationBarNumbers", barNumbers);
         map.addAttribute("searchTypes", SearchType.values());
+        map.addAttribute("searchTypeHashtag", SearchType.HASHTAG);
 
         return "articles/index";
     }
@@ -54,6 +55,7 @@ public class ArticleController {
         map.addAttribute("article",article);
         map.addAttribute("articleComments", article.articleCommentsResponse());
         map.addAttribute("totalCount", articleService.getArticleCount());
+        map.addAttribute("searchTypeHashtag", SearchType.HASHTAG);
 
         return "articles/detail";
     }

--- a/src/main/java/com/studyproject/boardproject/repository/ArticleRepository.java
+++ b/src/main/java/com/studyproject/boardproject/repository/ArticleRepository.java
@@ -26,7 +26,7 @@ public interface ArticleRepository extends
     Page<Article> findByUserAccount_UserIdContaining(String userId, Pageable pageable);
     Page<Article> findByUserAccount_NicknameContaining(String nickname, Pageable pageable);
 
-    void deleteByIdAndUserAccount_UserId(Long articleId, String userid);
+    void deleteByIdAndUserAccount_UserId(Long articleId, String userId);
 
     @Override
     default void customize(QuerydslBindings bindings, QArticle root) {

--- a/src/main/java/com/studyproject/boardproject/service/HashtagService.java
+++ b/src/main/java/com/studyproject/boardproject/service/HashtagService.java
@@ -1,19 +1,46 @@
 package com.studyproject.boardproject.service;
 
+import com.studyproject.boardproject.domain.Hashtag;
+import com.studyproject.boardproject.repository.HashtagRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+@RequiredArgsConstructor
 @Service
 public class HashtagService {
-    public Object parseHashtagNames(String content) {
-        return null;
+    private final HashtagRepository hashtagRepository;
+
+    public Set<String> parseHashtagNames(String content) {
+        if (content == null) {
+            return Set.of();
+        }
+
+        Pattern pattern = Pattern.compile("#[\\w가-힣]+");
+        Matcher matcher = pattern.matcher(content.strip());
+        Set<String> result = new HashSet<>();
+
+        while (matcher.find()) {
+            result.add(matcher.group().replace("#", ""));
+        }
+
+        return Set.copyOf(result); // 불변 Set으로 변경시 이렇게 사용
     }
 
-    public Object findHashtagsByNames(Set<String> expectedHashtagNames) {
-        return null;
+    public Set<Hashtag> findHashtagsByNames(Set<String> hashtagNames) {
+        // HashSet로 List를 변수로 넣어서 HashSet으로 변경
+        return new HashSet<>(hashtagRepository.findByHashtagNameIn(hashtagNames));
     }
 
-    public void deleteHashtagWithoutArticles(Object any) {
+    public void deleteHashtagWithoutArticles(Long hashtagId) {
+        Hashtag hashtag = hashtagRepository.getReferenceById(hashtagId);
+
+        if (hashtag.getArticles().isEmpty()) {
+            hashtagRepository.delete(hashtag);
+        }
     }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,9 +1,9 @@
 -- user account
 insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at, modified_by)
-values ('hyeon', '{noop}dummypassword', 'Hyeon', 'hyeon@mail.com', 'Hyeon', now(), 'hyeon', now(), 'hyeon');
+values ('hyeon', '{noop}dummy', 'Hyeon', 'hyeon@mail.com', 'Hyeon', now(), 'hyeon', now(), 'hyeon');
 
 insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at, modified_by)
-values ('hyeon2', '{noop}dummypassword2', 'Hyeon2', 'hyeon2@mail.com', 'Hyeon2', now(), 'hyeon2', now(), 'hyeon2');
+values ('hyeon2', '{noop}dummy', 'Hyeon2', 'hyeon2@mail.com', 'Hyeon2', now(), 'hyeon2', now(), 'hyeon2');
 
 -- article 102
 insert into article(user_id, title, content, created_by, created_at, modified_by, modified_at)

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -30,7 +30,7 @@
                     <p><span id="nickname">Hyeon</span></p>
                     <p><a id="email" rel="me" href="mailto:mrk19967@gmail.com">hyeon@mail.com</a></p>
                     <p><time id="created-at" datetime="2024-01-18T09:20:00">2024-01-18</time></p>
-                    <p id="hashtag">#java</p>
+                    <p id="hashtag" class="badge text-bg-secondary mx-1"><a class="text-reset">#java</a></p>
                 </aside>
             </section>
 

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -8,7 +8,12 @@
         <attr sel="#nickname" th:text="*{nickname}" />
         <attr sel="#email" th:text="*{email}" />
         <attr sel="#created-at" th:datetime="*{createdAt}" th:text="*{#temporals.format(createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
-        <attr sel="#hashtag" th:text="*{hashtag}" />
+        <attr sel="#hashtag" th:each="hashtag : ${article.hashtags}">
+            <attr sel="a"
+                  th:text="'#' + ${hashtag}"
+                  th:href="@{/articles(searchType=${searchTypeHashtag}, searchValue=${hashtag})}"
+            />
+        </attr>
         <attr sel="#article-content/pre" th:text="*{content}" />
     </attr>
 

--- a/src/main/resources/templates/articles/form.html
+++ b/src/main/resources/templates/articles/form.html
@@ -35,12 +35,12 @@
                    <textarea class="form-control" id="content" name="content" rows="5" required></textarea>
                </div>
            </div>
-           <div class="row mb-4 justify-content-md-center">
-               <label for="hashtag" class="col-sm-2 col-lg-1 col-form-label text-sm-end">해시태그</label>
-               <div class="col-sm-8 col-lg-9">
-                   <input type="text" class="form-control" id="hashtag" name="hashtag">
-               </div>
-           </div>
+<!--           <div class="row mb-4 justify-content-md-center">-->
+<!--               <label for="hashtag" class="col-sm-2 col-lg-1 col-form-label text-sm-end">해시태그</label>-->
+<!--               <div class="col-sm-8 col-lg-9">-->
+<!--                   <input type="text" class="form-control" id="hashtag" name="hashtag">-->
+<!--               </div>-->
+<!--           </div>-->
            <div class="row mb-5 justify-content-md-center">
                <div class="col-sm-10 d-grid gap-2 d-sm-flex justify-content-sm-end">
                    <button type="submit" class="btn btn-primary" id="submit-button">저장</button>

--- a/src/main/resources/templates/articles/form.th.xml
+++ b/src/main/resources/templates/articles/form.th.xml
@@ -8,7 +8,7 @@
     <attr sel="#article-form" th:action="${formStatus?.update} ? '/articles/' + ${article.id} + '/form' : '/articles/form'" th:method="post">
         <attr sel="#title" th:value="${article?.title} ?: _" />
         <attr sel="#content" th:text="${article?.content} ?: _" />
-        <attr sel="#hashtag" th:value="${article?.hashtag} ?: _" />
+<!--        <attr sel="#hashtag" th:value="${article?.hashtag} ?: _" />-->
         <attr sel="#submit-button" th:text="${formStatus?.description} ?: _" />
         <attr sel="#cancel-button" th:onclick="'history.back()'" />
     </attr>

--- a/src/main/resources/templates/articles/index.html
+++ b/src/main/resources/templates/articles/index.html
@@ -70,7 +70,7 @@
                 <tbody>
                     <tr>
                         <td class="title"><a>첫글</a></td>
-                        <td class="hashtag">#Java</td>
+                        <td class="hashtag"><span class="badge text-bg-secondary mx-1"><a class="text-reset">#Java</a></span></td>
                         <td class="user-id">Hyeon</td>
                         <td class="created-at"><time>2024-01-17</time></td>
                     </tr>

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -25,7 +25,7 @@
                 )}"/>
                 <attr sel="th.hashtag/a" th:text="'해시태그'" th:href="@{/articles(
                     page=${articles.number},
-                    sort='hashtag' + (*{sort.getOrderFor('hashtag')} != null ? (*{sort.getOrderFor('hashtag').direction.name} != 'DESC' ? ',desc' : '') : ''),
+                    sort='hashtags' + (*{sort.getOrderFor('hashtags')} != null ? (*{sort.getOrderFor('hashtags').direction.name} != 'DESC' ? ',desc' : '') : ''),
                     searchType=${param.searchType},
                     searchValue=${param.searchValue}
                 )}" />
@@ -46,7 +46,12 @@
             <attr sel="tbody" th:remove="all-but-first">
                 <attr sel="tr[0]" th:each="article : ${articles}">
                     <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}" />
-                    <attr sel="td.hashtag" th:text="${article.hashtag}" />
+                    <attr sel="td.hashtag/span" th:each="hashtag : ${article.hashtags}">
+                        <attr sel="a"
+                              th:text="'#' + ${hashtag}"
+                              th:href="@{/articles(searchType=${searchTypeHashtag}, searchValue=${hashtag})}"
+                        />
+                    </attr>
                     <attr sel="td.user-id" th:text="${article.nickname}" />
                     <attr sel="td.created-at/time" th:datetime="${article.createdAt}" th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}" />
                 </attr>

--- a/src/test/java/com/studyproject/boardproject/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/studyproject/boardproject/repository/JpaRepositoryTest.java
@@ -139,7 +139,7 @@ class JpaRepositoryTest {
         assertThat(articlePage.getContent().get(0).getTitle()).isEqualTo("test16");
         assertThat(articlePage.getContent().get(0).getHashtags())
                 .extracting("hashtagName", String.class)
-                .containsExactly("fuscia", "crimson", "teal");
+                .containsExactly("fuscia");
         assertThat(articlePage.getTotalElements()).isEqualTo(4);
         assertThat(articlePage.getTotalPages()).isEqualTo(2);
     }

--- a/src/test/java/com/studyproject/boardproject/service/ArticleServiceTest.java
+++ b/src/test/java/com/studyproject/boardproject/service/ArticleServiceTest.java
@@ -117,8 +117,7 @@ class ArticleServiceTest {
         String hashtagName = "java";
         Pageable pageable = Pageable.ofSize(20);
         Article expectedArticle = createArticle();
-        given(articleRepository.findByHashtagNames(List.of(hashtagName), pageable))
-                .willReturn(new PageImpl<>(List.of(), pageable, 0));
+        given(articleRepository.findByHashtagNames(List.of(hashtagName), pageable)).willReturn(new PageImpl<>(List.of(expectedArticle), pageable, 1));
 
         // When
         Page<ArticleDto> articles = sut.searchArticlesViaHashtag(hashtagName, pageable);
@@ -318,7 +317,7 @@ class ArticleServiceTest {
         String userId = "hyeon";
         given(articleRepository.getReferenceById(articleId)).willReturn(createArticle());
         willDoNothing().given(articleRepository).deleteByIdAndUserAccount_UserId(articleId, userId);
-        willDoNothing().given(articleRepository).deleteByIdAndUserAccount_UserId(articleId, userId);
+        willDoNothing().given(articleRepository).flush();
         willDoNothing().given(hashtagService).deleteHashtagWithoutArticles(any());
 
         // When

--- a/src/test/java/com/studyproject/boardproject/service/HashtagServiceTest.java
+++ b/src/test/java/com/studyproject/boardproject/service/HashtagServiceTest.java
@@ -1,0 +1,103 @@
+package com.studyproject.boardproject.service;
+
+import com.studyproject.boardproject.domain.Hashtag;
+import com.studyproject.boardproject.repository.HashtagRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.BDDMockito.*;
+
+@DisplayName("비지니스 로직 테스트 - 해시태그")
+@ExtendWith(MockitoExtension.class)
+class HashtagServiceTest {
+    @InjectMocks private HashtagService sut;
+
+    @Mock private HashtagRepository hashtagRepository;
+
+    @DisplayName("본문을 파싱하면, 해시태그 이름들을 중복없이 반환한다.")
+    @MethodSource
+    @ParameterizedTest(name = "[{index}] \"{0}\" => {1}")
+    void givenContent_whenParsing_thenReturnsUniqueHashtagName(String input, Set<String> expected) {
+        // Given
+
+        // When
+        Set<String> actual = sut.parseHashtagNames(input);
+
+        // Then
+        assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+        then(hashtagRepository).shouldHaveNoInteractions();
+    }
+
+    static Stream<Arguments> givenContent_whenParsing_thenReturnsUniqueHashtagName() {
+        return Stream.of(
+                arguments(null, Set.of()),
+                arguments("", Set.of()),
+                arguments("#", Set.of()),
+                arguments("#  ", Set.of()),
+                arguments("  #", Set.of()),
+                arguments("#java", Set.of("java")),
+                arguments("java#", Set.of()),
+                arguments("ja#va", Set.of("va")),
+                arguments("#java_spring", Set.of("java_spring")),
+                arguments("#java#spring", Set.of("java", "spring")),
+                arguments("#java #spring", Set.of("java", "spring")),
+                arguments("#java  #spring", Set.of("java", "spring")),
+                arguments("#java   #spring", Set.of("java", "spring")),
+                arguments("#java    #spring", Set.of("java", "spring")),
+                arguments(" #java    #spring", Set.of("java", "spring")),
+                arguments("  #java    #spring", Set.of("java", "spring")),
+                arguments("   #java    #spring", Set.of("java", "spring")),
+                arguments("    #java    #spring", Set.of("java", "spring")),
+                arguments("#java#spring#boot", Set.of("java", "spring", "boot")),
+                arguments("#java#java#spring#boot", Set.of("java", "spring", "boot")),
+                arguments("#java#java#java#spring#boot", Set.of("java", "spring", "boot")),
+                arguments("#java#java#spring#java#boot", Set.of("java", "spring", "boot")),
+                arguments("#java#spring #boot", Set.of("java", "spring", "boot")),
+                arguments("#java #spring#boot", Set.of("java", "spring", "boot")),
+                arguments("#java,#spring,#boot", Set.of("java", "spring", "boot")),
+                arguments("#java.#spring;#boot", Set.of("java", "spring", "boot")),
+                arguments("#java|#spring:#boot", Set.of("java", "spring", "boot")),
+                arguments("#java #spring #부트", Set.of("java", "spring", "부트")),
+                arguments("  #java.? #spring .... #부트", Set.of("java", "spring", "부트")),
+                arguments("#java#부트 dummy dummy content content", Set.of("java", "부트")),
+                arguments("dummy dummy content content#java#부트", Set.of("java", "부트")),
+                arguments("dummy dummy#java#부트~~~~~~~~~~~~~~", Set.of("java", "부트")),
+                arguments("dummy dummy#java~~~~~~~~~~~~~~#부트~~~~~~~~~~~~~~", Set.of("java", "부트")),
+                arguments("#java-spring", Set.of("java")),
+                arguments("#_java_spring", Set.of("_java_spring")),
+                arguments("#-java-spring", Set.of()),
+                arguments("#_java_spring__", Set.of("_java_spring__"))
+        );
+    }
+
+    @DisplayName("해시태그 이름들을 입력하면, 저장된 해스태그 중 이름에 매칭하는 것들을 중복없이 반환한다.")
+    @Test
+    void givenHashtagNames_whenFindingHashtags_thenReturnsHashtagSet() {
+        // Given
+        Set<String> hashtagNames = Set.of("java", "spring", "boot");
+        given(hashtagRepository.findByHashtagNameIn(hashtagNames)).willReturn(List.of(
+                Hashtag.of("java"),
+                Hashtag.of("spring")
+        ));
+
+        // When
+        Set<Hashtag> hashtags = sut.findHashtagsByNames(hashtagNames);
+
+        // Then
+        assertThat(hashtags).hasSize(2);
+        then(hashtagRepository).should().findByHashtagNameIn(hashtagNames);
+    }
+}


### PR DESCRIPTION
* ArticleRepository의 오타 수정과 Jpa, ArticleServie 테스트에서 잘못된 부분 수정
* data.sql의 user의 비밀번호가 길어서 로그인하기 쉽게 짧은 비밀번호 설정
* 해시태그 고도화하면서 통과 못한 테스트를 위해 비지니스 로직과 컨트롤러 수정
    - ArticleService에 updateArticle의 equals부분에 userAccount와 article.getUserAccount가 여러번 찍어 봤을때 같은 값임에도 불구하고 인식이 안되어서 임시방편으로 작업해둠
* 해시태그 바뀐 것이 뷰에서 제대로 작용할 수 있도록 뷰 수정
