### PR TITLE
댓글 기능 고도화 - 대댓글 기능

### DIFF
--- a/src/main/java/com/studyproject/boardproject/domain/ArticleComment.java
+++ b/src/main/java/com/studyproject/boardproject/domain/ArticleComment.java
@@ -5,7 +5,9 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Set;
 
 @Getter
 @ToString(callSuper = true)
@@ -28,18 +30,33 @@ public class ArticleComment extends AuditingFields {
     @ManyToOne(optional = false)
     private UserAccount userAccount; // 유저 정보 (ID)
 
+    @Setter
+    @Column(updatable = false) // 수정 불가능하게 설정
+    private Long parentCommentId; // 부모 대슬 ID
+
+    @ToString.Exclude
+    @OrderBy("createdAt ASC")
+    @OneToMany(mappedBy = "parentCommentId", cascade = CascadeType.ALL)
+    private Set<ArticleComment> childComments = new LinkedHashSet<>();
+
     @Setter @Column(nullable = false, length = 500) private String content; // 내용
 
     protected ArticleComment() {}
 
-    private ArticleComment (Article article, UserAccount userAccount, String content) {
+    private ArticleComment (Article article, UserAccount userAccount, Long parentCommentId, String content) {
         this.article = article;
         this.userAccount = userAccount;
         this.content = content;
+        this.parentCommentId = parentCommentId;
     }
 
     public static ArticleComment of(Article article, UserAccount userAccount, String content) {
-        return new ArticleComment(article, userAccount, content);
+        return new ArticleComment(article, userAccount, null, content);
+    }
+
+    public void addChildComment(ArticleComment child) {
+        child.setParentCommentId(this.getId());
+        this.getChildComments().add(child);
     }
 
     @Override

--- a/src/main/java/com/studyproject/boardproject/dto/ArticleCommentDto.java
+++ b/src/main/java/com/studyproject/boardproject/dto/ArticleCommentDto.java
@@ -10,6 +10,7 @@ public record ArticleCommentDto(
         Long id,
         Long articleId,
         UserAccountDto userAccountDto,
+        Long parentCommentId,
         String content,
         LocalDateTime createdAt,
         String createdBy,
@@ -18,11 +19,15 @@ public record ArticleCommentDto(
 ) {
 
     public static ArticleCommentDto of(Long articleId, UserAccountDto userAccountDto, String content) {
-        return new ArticleCommentDto(null, articleId, userAccountDto, content, null, null, null, null);
+        return ArticleCommentDto.of(articleId, userAccountDto, null, content);
     }
 
-    public static ArticleCommentDto of(Long id, Long articleId, UserAccountDto userAccountDto, String content, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
-        return new ArticleCommentDto(id, articleId, userAccountDto, content, createdAt, createdBy, modifiedAt, modifiedBy);
+    public static ArticleCommentDto of(Long articleId, UserAccountDto userAccountDto, Long parentCommentId, String content) {
+        return ArticleCommentDto.of(null, articleId, userAccountDto, parentCommentId, content, null, null, null, null);
+    }
+
+    public static ArticleCommentDto of(Long id, Long articleId, UserAccountDto userAccountDto, Long parentCommentId, String content, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new ArticleCommentDto(id, articleId, userAccountDto, parentCommentId, content, createdAt, createdBy, modifiedAt, modifiedBy);
     }
 
     public static ArticleCommentDto from(ArticleComment entity) {
@@ -30,6 +35,7 @@ public record ArticleCommentDto(
                 entity.getId(),
                 entity.getArticle().getId(),
                 UserAccountDto.from(entity.getUserAccount()),
+                entity.getParentCommentId(),
                 entity.getContent(),
                 entity.getCreatedAt(),
                 entity.getCreatedBy(),

--- a/src/main/java/com/studyproject/boardproject/dto/request/ArticleCommentRequest.java
+++ b/src/main/java/com/studyproject/boardproject/dto/request/ArticleCommentRequest.java
@@ -3,16 +3,25 @@ package com.studyproject.boardproject.dto.request;
 import com.studyproject.boardproject.dto.ArticleCommentDto;
 import com.studyproject.boardproject.dto.UserAccountDto;
 
-public record ArticleCommentRequest(Long articleId, String content) {
+public record ArticleCommentRequest(
+        Long articleId,
+        Long parentCommentId,
+        String content
+) {
 
     public static ArticleCommentRequest of(Long articleId, String content) {
-        return new ArticleCommentRequest(articleId, content);
+        return ArticleCommentRequest.of(articleId, null, content);
+    }
+
+    public static ArticleCommentRequest of(Long articleId, Long parentCommentId, String content) {
+        return new ArticleCommentRequest(articleId, parentCommentId, content);
     }
 
     public ArticleCommentDto toDto(UserAccountDto userAccountDto) {
         return ArticleCommentDto.of(
                 articleId,
                 userAccountDto,
+                parentCommentId,
                 content
         );
     }

--- a/src/main/java/com/studyproject/boardproject/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/com/studyproject/boardproject/dto/response/ArticleCommentResponse.java
@@ -3,17 +3,30 @@ package com.studyproject.boardproject.dto.response;
 import com.studyproject.boardproject.dto.ArticleCommentDto;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.TreeSet;
 
 public record ArticleCommentResponse(
         Long id,
         String content,
         String userId,
         String nickname,
+        Long parentCommentId,
+        Set<ArticleCommentResponse> childComments,
         String email,
         LocalDateTime createdAt
 ) {
     public static ArticleCommentResponse of(Long id, String content, String userId, String nickname, String email, LocalDateTime createdAt) {
-        return new ArticleCommentResponse(id, content, userId, nickname, email, createdAt);
+        return ArticleCommentResponse.of(id, content, userId, nickname, null, email, createdAt);
+    }
+
+    public static ArticleCommentResponse of(Long id, String content, String userId, String nickname, Long parentCommentId, String email, LocalDateTime createdAt) {
+        // 대댓글이 시간의 순서대로 출력되야 하므로 순서를 셋팅하는 로직
+        Comparator<ArticleCommentResponse> childCommentComparator = Comparator
+                .comparing(ArticleCommentResponse::createdAt) // 시간의 순서대로 , 반대로 할경우 reverse()를 사용
+                .thenComparingLong(ArticleCommentResponse::id); // 만약 시간이 완전히 똑같을 경우 아이디로 순서를 적용
+        return new ArticleCommentResponse(id, content, userId, nickname, parentCommentId, new TreeSet<>(childCommentComparator), email, createdAt);
     }
 
     public static ArticleCommentResponse from(ArticleCommentDto dto) {
@@ -23,13 +36,18 @@ public record ArticleCommentResponse(
             nickname = dto.userAccountDto().userId();
         }
 
-        return new ArticleCommentResponse(
+        return ArticleCommentResponse.of(
                 dto.id(),
                 dto.content(),
                 dto.userAccountDto().userId(),
                 nickname,
+                dto.parentCommentId(),
                 dto.userAccountDto().email(),
                 dto.createdAt()
         );
+    }
+
+    public boolean hasParentComment() {
+        return parentCommentId != null;
     }
 }

--- a/src/main/java/com/studyproject/boardproject/dto/response/ArticleWithCommentsResponse.java
+++ b/src/main/java/com/studyproject/boardproject/dto/response/ArticleWithCommentsResponse.java
@@ -1,11 +1,12 @@
 package com.studyproject.boardproject.dto.response;
 
+import com.studyproject.boardproject.dto.ArticleCommentDto;
 import com.studyproject.boardproject.dto.ArticleWithCommentsDto;
 import com.studyproject.boardproject.dto.HashtagDto;
 
 import java.time.LocalDateTime;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public record ArticleWithCommentsResponse(
@@ -42,10 +43,36 @@ public record ArticleWithCommentsResponse(
                 dto.userAccountDto().userId(),
                 nickname,
                 dto.userAccountDto().email(),
-                dto.articleCommentDtos().stream()
-                        .map(ArticleCommentResponse::from)
-                        .collect(Collectors.toCollection(LinkedHashSet::new)),
+                organizeChildComments(dto.articleCommentDtos()),
                 dto.createdAt()
         );
+    }
+
+    private static Set<ArticleCommentResponse> organizeChildComments(Set<ArticleCommentDto> dtos) {
+        // [articleComment의 id, ArticleCommentResponse] 로 매핑
+        Map<Long, ArticleCommentResponse> map = dtos.stream()
+                .map(ArticleCommentResponse::from)
+                .collect(Collectors.toMap(ArticleCommentResponse::id, Function.identity()));
+
+        // 부모 comment가 있을 경우 자식 comment를 부모 comment의 Set에 포함
+        // [articleComment의 id, ArticleCommentResponse.childComments안에 포함]
+        map.values().stream()
+                .filter(ArticleCommentResponse::hasParentComment)
+                .forEach(comment -> {
+                    ArticleCommentResponse parentComment = map.get(comment.parentCommentId());
+                    parentComment.childComments().add(comment);
+                });
+        
+        // 댓글 순서를 정렬
+        return map.values().stream()
+                .filter(comment -> !comment.hasParentComment())
+                .collect(Collectors.toCollection(() ->
+                        // 순서를 가져야 하므로 TreeSet사용
+                        new TreeSet<>(Comparator
+                                .comparing(ArticleCommentResponse::createdAt)
+                                .reversed()
+                                .thenComparing(ArticleCommentResponse::id)
+                        )
+                    ));
     }
 }

--- a/src/main/java/com/studyproject/boardproject/service/ArticleCommentService.java
+++ b/src/main/java/com/studyproject/boardproject/service/ArticleCommentService.java
@@ -37,7 +37,14 @@ public class ArticleCommentService {
         try {
             Article article = articleRepository.getReferenceById(dto.articleId());
             UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
-            articleCommentRepository.save(dto.toEntity(article, userAccount));
+            ArticleComment articleComment = dto.toEntity(article, userAccount);
+
+            if (dto.parentCommentId() != null) {
+                ArticleComment parentComment = articleCommentRepository.getReferenceById(dto.parentCommentId());
+                parentComment.addChildComment(articleComment);
+            } else {
+                articleCommentRepository.save(articleComment);
+            }
         } catch (EntityNotFoundException e) {
             log.warn("댓글 저장 실패. 댓글 작성에 필요한 정보를 찾을 수 없습니다 - {}", e.getLocalizedMessage());
         }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -111,33 +111,41 @@ values ('hyeon2', 'test1', 'content1 #gold', 'hyeon2', '2022-01-12', 'hyeon2', '
        ('hyeon2', 'dummytitle70', 'dummy content....dummy content....dummy content...', 'hyeon2', '2022-02-11', 'hyeon2', '2022-02-11');
 
 -- article comment 26
-insert into article_comment (article_id, user_id, content, created_by, created_at, modified_by, modified_at)
-values  (1, 'hyeon2', 'content1', 'hyeon2', '2022-01-12', 'hyeon2', '2022-01-12'),
-        (2, 'hyeon2', 'content2', 'hyeon2', '2022-01-13', 'hyeon2', '2022-01-13'),
-        (3, 'hyeon2', 'content3', 'hyeon2', '2022-01-14', 'hyeon2', '2022-01-14'),
-        (4, 'hyeon2', 'content4', 'hyeon2', '2022-01-15', 'hyeon2', '2022-01-15'),
-        (5, 'hyeon', 'content5', 'hyeon', '2022-01-16', 'hyeon', '2022-01-16'),
-        (6, 'hyeon', 'content6', 'hyeon', '2022-01-17', 'hyeon', '2022-01-17'),
-        (7, 'hyeon', 'content7', 'hyeon', '2022-01-18', 'hyeon', '2022-01-18'),
-        (8, 'hyeon', 'content8', 'hyeon', '2022-01-19', 'hyeon', '2022-01-19'),
-        (9, 'hyeon', 'content9', 'hyeon', '2022-01-20', 'hyeon', '2022-01-20'),
-        (10, 'hyeon2', 'content10', 'hyeon2', '2022-01-21', 'hyeon2', '2022-01-21'),
-        (1, 'hyeon2', 'content11',  'hyeon2', '2022-01-22', 'hyeon2', '2022-01-22'),
-        (2, 'hyeon', 'content12', 'hyeon', '2022-01-23', 'hyeon', '2022-01-23'),
-        (2, 'hyeon2', 'content13', 'hyeon', '2022-01-24', 'hyeon', '2022-01-24'),
-        (3, 'hyeon', 'content14', 'hyeon', '2022-01-25', 'hyeon', '2022-01-25'),
-        (3, 'hyeon', 'content15', 'hyeon', '2022-01-25', 'hyeon', '2022-01-25'),
-        (3, 'hyeon', 'content16', 'hyeon', '2022-01-25', 'hyeon', '2022-01-25'),
-        (3, 'hyeon2', 'content17', 'hyeon2', '2022-01-26', 'hyeon2', '2022-01-26'),
-        (3, 'hyeon2', 'content18', 'hyeon2', '2022-01-26', 'hyeon2', '2022-01-26'),
-        (3, 'hyeon2', 'content19', 'hyeon2', '2022-01-26', 'hyeon2', '2022-01-26'),
-        (102, 'hyeon2', 'content20', 'hyeon2', '2022-01-26', 'hyeon2', '2022-01-26'),
-        (102, 'hyeon', 'content21', 'hyeon', '2022-01-27', 'hyeon', '2022-01-27'),
-        (102, 'hyeon2', 'content22', 'hyeon2', '2022-01-27', 'hyeon2', '2022-01-27'),
-        (102, 'hyeon', 'content23', 'hyeon', '2022-01-28', 'hyeon', '2022-01-28'),
-        (102, 'hyeon2', 'content24', 'hyeon2', '2022-01-28', 'hyeon2', '2022-01-28'),
-        (102, 'hyeon', 'content25', 'hyeon', '2022-01-29', 'hyeon', '2022-01-29'),
-        (102, 'hyeon2', 'content26', 'hyeon2', '2022-01-29', 'hyeon2', '2022-01-29');
+insert into article_comment (article_id, user_id, parent_comment_id, content, created_by, created_at, modified_by, modified_at)
+values  (1, 'hyeon2', null, 'content1', 'hyeon2', '2022-01-12', 'hyeon2', '2022-01-12'),
+        (2, 'hyeon2', null, 'content2', 'hyeon2', '2022-01-13', 'hyeon2', '2022-01-13'),
+        (3, 'hyeon2', null, 'content3', 'hyeon2', '2022-01-14', 'hyeon2', '2022-01-14'),
+        (4, 'hyeon2', null, 'content4', 'hyeon2', '2022-01-15', 'hyeon2', '2022-01-15'),
+        (5, 'hyeon', null, 'content5', 'hyeon', '2022-01-16', 'hyeon', '2022-01-16'),
+        (6, 'hyeon', null, 'content6', 'hyeon', '2022-01-17', 'hyeon', '2022-01-17'),
+        (7, 'hyeon', null, 'content7', 'hyeon', '2022-01-18', 'hyeon', '2022-01-18'),
+        (8, 'hyeon', null, 'content8', 'hyeon', '2022-01-19', 'hyeon', '2022-01-19'),
+        (9, 'hyeon', null, 'content9', 'hyeon', '2022-01-20', 'hyeon', '2022-01-20'),
+        (10, 'hyeon2', null, 'content10', 'hyeon2', '2022-01-21', 'hyeon2', '2022-01-21'),
+        (1, 'hyeon2', null, 'content11',  'hyeon2', '2022-01-22', 'hyeon2', '2022-01-22'),
+        (2, 'hyeon', null, 'content12', 'hyeon', '2022-01-23', 'hyeon', '2022-01-23'),
+        (2, 'hyeon2', null, 'content13', 'hyeon', '2022-01-24', 'hyeon', '2022-01-24'),
+        (3, 'hyeon', null, 'content14', 'hyeon', '2022-01-25', 'hyeon', '2022-01-25'),
+        (3, 'hyeon', null, 'content15', 'hyeon', '2022-01-25', 'hyeon', '2022-01-25'),
+        (3, 'hyeon', null, 'content16', 'hyeon', '2022-01-25', 'hyeon', '2022-01-25'),
+        (3, 'hyeon2', null, 'content17', 'hyeon2', '2022-01-26', 'hyeon2', '2022-01-26'),
+        (3, 'hyeon2', null, 'content18', 'hyeon2', '2022-01-26', 'hyeon2', '2022-01-26'),
+        (3, 'hyeon2', null, 'content19', 'hyeon2', '2022-01-26', 'hyeon2', '2022-01-26'),
+        (102, 'hyeon2', null, 'content20', 'hyeon2', '2022-01-26', 'hyeon2', '2022-01-26'),
+        (102, 'hyeon', null, 'content21', 'hyeon', '2022-01-27', 'hyeon', '2022-01-27'),
+        (102, 'hyeon2', null, 'content22', 'hyeon2', '2022-01-27', 'hyeon2', '2022-01-27'),
+        (102, 'hyeon', null, 'content23', 'hyeon', '2022-01-28', 'hyeon', '2022-01-28'),
+        (102, 'hyeon2', null, 'content24', 'hyeon2', '2022-01-28', 'hyeon2', '2022-01-28'),
+        (102, 'hyeon', null, 'content25', 'hyeon', '2022-01-29', 'hyeon', '2022-01-29'),
+        (102, 'hyeon2', null, 'content26', 'hyeon2', '2022-01-29', 'hyeon2', '2022-01-29');
+
+-- 대댓글 5
+insert into article_comment (article_id, user_id, parent_comment_id, content, created_by, created_at, modified_by, modified_at)
+values  (102, 'hyeon2', 24, 'content_comment1', 'hyeon2', '2022-01-12', 'hyeon2', '2022-01-12'),
+        (102, 'hyeon', 24, 'content_comment2', 'hyeon', '2022-01-13', 'hyeon2', '2022-01-13'),
+        (102, 'hyeon2', 24, 'content_comment3', 'hyeon2', '2022-01-14', 'hyeon2', '2022-01-14'),
+        (102, 'hyeon', 24, 'content_comment3', 'hyeon', '2022-01-15', 'hyeon', '2022-01-15'),
+        (102, 'hyeon2', 24, 'content_comment3', 'hyeon2', '2022-01-16', 'hyeon2', '2022-01-16');
 
 -- hashtag 20
 insert into hashtag(hashtag_name, created_at, created_by, modified_at, modified_by) values

--- a/src/test/java/com/studyproject/boardproject/controller/ArticleCommentControllerTest.java
+++ b/src/test/java/com/studyproject/boardproject/controller/ArticleCommentControllerTest.java
@@ -84,4 +84,27 @@ class ArticleCommentControllerTest {
 
         then(articleCommentService).should().deleteArticleComment(articleCommentId, userId);
     }
+
+    @WithUserDetails(value = "hyeonTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    @DisplayName("[view/POST] 대댓글 등록 - 정상 호출")
+    @Test
+    public void givenArticleCommentInfoWithParentCommentId_whenRequesting_thenSavesNewChildArticleComment() throws Exception {
+        // Given
+        long articleId = 1L;
+        ArticleCommentRequest request = ArticleCommentRequest.of(articleId, 1L, "test comment");
+        willDoNothing().given(articleCommentService).saveArticleComment(any(ArticleCommentDto.class));
+
+        // When&Then
+        mvc.perform( post("/comments/new")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .content(formDataEncoder.encode(request))
+                        .with(csrf())
+                )
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/articles/" + articleId))
+                .andExpect(redirectedUrl("/articles/" + articleId));
+
+        then(articleCommentService).should().saveArticleComment(any(ArticleCommentDto.class));
+    }
+
 }

--- a/src/test/java/com/studyproject/boardproject/dto/response/ArticleWithCommentsResponseTest.java
+++ b/src/test/java/com/studyproject/boardproject/dto/response/ArticleWithCommentsResponseTest.java
@@ -1,0 +1,180 @@
+package com.studyproject.boardproject.dto.response;
+
+import com.studyproject.boardproject.dto.ArticleCommentDto;
+import com.studyproject.boardproject.dto.ArticleWithCommentsDto;
+import com.studyproject.boardproject.dto.HashtagDto;
+import com.studyproject.boardproject.dto.UserAccountDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Iterator;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("DTO - 댓글을 포함한 게시글 응답 테스트")
+class ArticleWithCommentsResponseTest {
+
+    @DisplayName("자식 댓글이 없는 게시글 + 댓글 DTO를 API 응답으로 변환할 때, 댓글을 시간의 내림차순  + ID를 오름차순으로 정렬한다.")
+    @Test
+    public void givenArticleWithCommentsDtoWithoutChildComments_whenMapping_thenOrganizesCommentsWithCertainOrder() {
+        // Given
+        LocalDateTime now = LocalDateTime.now();
+        Set<ArticleCommentDto> articleCommentDtos = Set.of(
+                createArticleCommentDto(1L, null, now),
+                createArticleCommentDto(2L, null, now.plusDays(1L)),
+                createArticleCommentDto(3L, null, now.plusDays(3L)),
+                createArticleCommentDto(4L, null, now),
+                createArticleCommentDto(5L, null, now.plusDays(5L)),
+                createArticleCommentDto(6L, null, now.plusDays(4L)),
+                createArticleCommentDto(7L, null, now.plusDays(2L)),
+                createArticleCommentDto(8L, null, now.plusDays(7L))
+        );
+        ArticleWithCommentsDto input = createArticleWithCommentsDto(articleCommentDtos);
+
+        // When
+        ArticleWithCommentsResponse actual = ArticleWithCommentsResponse.from(input);
+
+        // Then
+        assertThat(actual.articleCommentsResponse())
+                .containsExactly(
+                        createArticleCommentResponse(8L, null, now.plusDays(7L)),
+                        createArticleCommentResponse(5L, null, now.plusDays(5L)),
+                        createArticleCommentResponse(6L, null, now.plusDays(4L)),
+                        createArticleCommentResponse(3L, null, now.plusDays(3L)),
+                        createArticleCommentResponse(7L, null, now.plusDays(2L)),
+                        createArticleCommentResponse(2L, null, now.plusDays(1L)),
+                        createArticleCommentResponse(1L, null, now),
+                        createArticleCommentResponse(4L, null, now)
+                );
+    }
+
+    @DisplayName("게시글 + 댓글 DTO를 API 응답으로 변환할 때, 댓글 부모 자식 관계를 각각 규칙으로 정렬하여 정리한다.")
+    @Test
+    public void givenArticleWithCommentsDto_whenMapping_thenOrganizesParentAndChildCommentsWithCertainOrders() {
+        // Given
+        LocalDateTime now = LocalDateTime.now();
+        Set<ArticleCommentDto> articleCommentDtos = Set.of(
+                createArticleCommentDto(1L, null, now),
+                createArticleCommentDto(2L, 1L, now.plusDays(1L)),
+                createArticleCommentDto(3L, 1L, now.plusDays(3L)),
+                createArticleCommentDto(4L, 1L, now),
+                createArticleCommentDto(5L, null, now.plusDays(5L)),
+                createArticleCommentDto(6L, null, now.plusDays(4L)),
+                createArticleCommentDto(7L, 6L, now.plusDays(2L)),
+                createArticleCommentDto(8L, 6L, now.plusDays(7L))
+        );
+        ArticleWithCommentsDto input = createArticleWithCommentsDto(articleCommentDtos);
+
+        // When
+        ArticleWithCommentsResponse actual = ArticleWithCommentsResponse.from(input);
+
+        // Then
+        assertThat(actual.articleCommentsResponse())
+                .containsExactly(
+                        createArticleCommentResponse(5L, null, now.plusDays(5)),
+                        createArticleCommentResponse(6L, null, now.plusDays(4)),
+                        createArticleCommentResponse(1L, null, now)
+                ).flatExtracting(ArticleCommentResponse::childComments)
+                .containsExactly(
+                        createArticleCommentResponse(7L, 6L, now.plusDays(2)),
+                        createArticleCommentResponse(8L, 6L, now.plusDays(7)),
+                        createArticleCommentResponse(4L, 1L, now),
+                        createArticleCommentResponse(2L, 1L, now.plusDays(1)),
+                        createArticleCommentResponse(3L, 1L, now.plusDays(3))
+                );
+    }
+
+    @DisplayName("게시글 + 댓글 DTO를 API 응답으로 변환할 떄, 부모 자식 관계 깊이(depth)는 제한이 없다.")
+    @Test
+    public void givenArticleWithCommentsDto_whenMapping_thenOrganizesParentAndChildCommentsWithoutDepthLimit() {
+        // Given
+        LocalDateTime now = LocalDateTime.now();
+        Set<ArticleCommentDto> articleCommentDtos = Set.of(
+                createArticleCommentDto(1L, null, now),
+                createArticleCommentDto(2L, 1L, now.plusDays(1L)),
+                createArticleCommentDto(3L, 2L, now.plusDays(2L)),
+                createArticleCommentDto(4L, 3L, now.plusDays(3L)),
+                createArticleCommentDto(5L, 4L, now.plusDays(4L)),
+                createArticleCommentDto(6L, 5L, now.plusDays(5L)),
+                createArticleCommentDto(7L, 6L, now.plusDays(6L)),
+                createArticleCommentDto(8L, 7L, now.plusDays(7L))
+        );
+        ArticleWithCommentsDto input = createArticleWithCommentsDto(articleCommentDtos);
+
+        // When
+        ArticleWithCommentsResponse actual = ArticleWithCommentsResponse.from(input);
+
+        // Then
+        Iterator<ArticleCommentResponse> iterator = actual.articleCommentsResponse().iterator();
+        Long i = 1L;
+
+        while (iterator.hasNext()) {
+            ArticleCommentResponse articleCommentResponse = iterator.next();
+            assertThat(articleCommentResponse)
+                    .hasFieldOrPropertyWithValue("id", i)
+                    .hasFieldOrPropertyWithValue("parentCommentId", i == 1L ? null : i - 1L)
+                    .hasFieldOrPropertyWithValue("createdAt", now.plusDays(i - 1L));
+
+            iterator = articleCommentResponse.childComments().iterator();
+            i++;
+        }
+    }
+
+    //fixture
+    private ArticleWithCommentsDto createArticleWithCommentsDto(Set<ArticleCommentDto> articleCommentDtos) {
+        return ArticleWithCommentsDto.of(
+                1L,
+                createUserAccountDto(),
+                articleCommentDtos,
+                "title",
+                "content",
+                Set.of(HashtagDto.of("java")),
+                LocalDateTime.now(),
+                "hyeon",
+                LocalDateTime.now(),
+                "hyeon"
+        );
+    }
+
+    private UserAccountDto createUserAccountDto() {
+        return UserAccountDto.of(
+                "hyeon",
+                "dummy",
+                "hyeon@email.com",
+                "Hyeon",
+                "memo",
+                LocalDateTime.now(),
+                "hyeon",
+                LocalDateTime.now(),
+                "hyeon"
+        );
+    }
+
+    private ArticleCommentDto createArticleCommentDto(Long id, Long parentCommentId, LocalDateTime createdAt) {
+        return ArticleCommentDto.of(
+                id,
+                1L,
+                createUserAccountDto(),
+                parentCommentId,
+                "test comment " + id,
+                createdAt,
+                "hyeon",
+                LocalDateTime.now(),
+                "hyeon"
+        );
+    }
+
+    private ArticleCommentResponse createArticleCommentResponse(Long id, Long parentCommentId, LocalDateTime createdAt) {
+        return ArticleCommentResponse.of(
+                id,
+                "test comment " + id,
+                "hyeon",
+                "Hyeon",
+                parentCommentId,
+                "hyeon@email.com",
+                createdAt
+        );
+    }
+}

--- a/src/test/java/com/studyproject/boardproject/service/ArticleCommentServiceTest.java
+++ b/src/test/java/com/studyproject/boardproject/service/ArticleCommentServiceTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -39,16 +40,25 @@ class ArticleCommentServiceTest {
     void givenArticleId_whenSearchingArticleComments_thenReturnsArticleComments() {
         // Given
         Long articleId = 1L;
-        ArticleComment expected = createArticleComment("content");
-        given(articleCommentRepository.findByArticle_Id(articleId)).willReturn(List.of(expected));
+        ArticleComment expectedParentComment = createArticleComment(1L, "parent content");
+        ArticleComment expectedChildComment = createArticleComment(2L, "child content");
+        expectedChildComment.setParentCommentId(expectedParentComment.getId());
+        given(articleCommentRepository.findByArticle_Id(articleId)).willReturn(List.of(
+                expectedParentComment,
+                expectedChildComment
+        ));
 
         // When
         List<ArticleCommentDto> actual = sut.searchArticleComments(articleId);
 
         // Then
+        assertThat(actual).hasSize(2);
         assertThat(actual)
-                .hasSize(1)
-                .first().hasFieldOrPropertyWithValue("content", expected.getContent());
+                .extracting("id", "articleId", "parentCommentId", "content")
+                .containsExactlyInAnyOrder(
+                        tuple(1L, 1L, null, "parent content"),
+                        tuple(2L, 1L, 1L, "child content")
+                );
 
         then(articleCommentRepository).should().findByArticle_Id(articleId);
     }
@@ -68,6 +78,7 @@ class ArticleCommentServiceTest {
         // Then
         then(articleRepository).should().getReferenceById(dto.articleId());
         then(userAccountRepository).should().getReferenceById(dto.userAccountDto().userId());
+        then(articleCommentRepository).should(never()).getReferenceById(anyLong());
         then(articleCommentRepository).should().save(any(ArticleComment.class));
     }
 
@@ -86,27 +97,27 @@ class ArticleCommentServiceTest {
         then(userAccountRepository).shouldHaveNoInteractions();
         then(articleCommentRepository).shouldHaveNoInteractions();
     }
-
-    @DisplayName("댓글 정보를 입력하면, 댓글을 수정한다.")
-    @Test
-    void givenArticleCommentInfo_whenUpdatingArticleComment_thenUpdatesArticleComment() {
-        // Given
-        String oldContent = "옛날 댓글";
-        String updateContent = "새 댓글";
-        ArticleComment articleComment = createArticleComment(oldContent);
-        ArticleCommentDto dto = createArticleCommentDto(updateContent);
-        given(articleCommentRepository.getReferenceById(dto.id())).willReturn(articleComment);
-
-        // When
-        sut.updateArticleComment(dto);
-
-        // Then
-        assertThat(articleComment.getContent())
-                .isNotEqualTo(oldContent)
-                .isEqualTo(updateContent);
-
-        then(articleCommentRepository).should().getReferenceById(dto.id());
-    }
+      // 댓글 수정 기능을 사용하지 않으므로 제거
+//    @DisplayName("댓글 정보를 입력하면, 댓글을 수정한다.")
+//    @Test
+//    void givenArticleCommentInfo_whenUpdatingArticleComment_thenUpdatesArticleComment() {
+//        // Given
+//        String oldContent = "옛날 댓글";
+//        String updateContent = "새 댓글";
+//        ArticleComment articleComment = createArticleComment(oldContent);
+//        ArticleCommentDto dto = createArticleCommentDto(updateContent);
+//        given(articleCommentRepository.getReferenceById(dto.id())).willReturn(articleComment);
+//
+//        // When
+//        sut.updateArticleComment(dto);
+//
+//        // Then
+//        assertThat(articleComment.getContent())
+//                .isNotEqualTo(oldContent)
+//                .isEqualTo(updateContent);
+//
+//        then(articleCommentRepository).should().getReferenceById(dto.id());
+//    }
 
     @DisplayName("없는 댓글 정보를 수정하려고 하면, 경고 로그를 찍고 아무 것도 안 한다.")
     @Test
@@ -137,12 +148,46 @@ class ArticleCommentServiceTest {
         then(articleCommentRepository).should().deleteByIdAndUserAccount_UserId(articleCommentId, userId);
     }
 
+    @DisplayName("부모 댓글 ID와 댓글 정보를 입력하면, 대댓글을 저장한다.")
+    @Test
+    public void givenParentCommentIdAndArticleCommentInfo_whenSaving_thenSavesChildComment() {
+        // Given
+        Long parentCommentId = 1L;
+        ArticleComment parent = createArticleComment(parentCommentId, "댓글");
+        ArticleCommentDto child = createArticleCommentDto(parentCommentId, "대댓글");
+        given(articleRepository.getReferenceById(child.articleId())).willReturn(createArticle());
+        given(userAccountRepository.getReferenceById(child.userAccountDto().userId())).willReturn(createUserAccount());
+        given(articleCommentRepository.getReferenceById(child.parentCommentId())).willReturn(parent);
+
+        // When
+        sut.saveArticleComment(child);
+
+        // Then
+        assertThat(child.parentCommentId()).isNotNull();
+        then(articleRepository).should().getReferenceById(child.articleId());
+        then(userAccountRepository).should().getReferenceById(child.userAccountDto().userId());
+        then(articleCommentRepository).should().getReferenceById(child.parentCommentId());
+        then(articleCommentRepository).should(never()).save(any(ArticleComment.class));
+
+
+    }
+
+
     // fixture 작성
     private ArticleCommentDto createArticleCommentDto(String content) {
+        return createArticleCommentDto(null, content);
+    }
+
+    private ArticleCommentDto createArticleCommentDto(Long parentCommentId, String content) {
+        return createArticleCommentDto(1L, parentCommentId, content);
+    }
+
+    private ArticleCommentDto createArticleCommentDto(Long id, Long parentCommentId, String content) {
         return ArticleCommentDto.of(
-                1L,
+                id,
                 1L,
                 createUserAccountDto(),
+                parentCommentId,
                 content,
                 LocalDateTime.now(),
                 "hyeon",
@@ -165,12 +210,15 @@ class ArticleCommentServiceTest {
         );
     }
 
-    private ArticleComment createArticleComment(String content) {
-        return ArticleComment.of(
+    private ArticleComment createArticleComment(Long id, String content) {
+        ArticleComment articleComment = ArticleComment.of(
                 createArticle(),
                 createUserAccount(),
                 content
         );
+        ReflectionTestUtils.setField(articleComment, "id", id);
+
+        return articleComment;
     }
 
     private UserAccount createUserAccount() {
@@ -190,6 +238,7 @@ class ArticleCommentServiceTest {
                 "content"
         );
 
+        ReflectionTestUtils.setField(article, "id", 1L);
         article.addHashtags(Set.of(createHashtag(article)));
 
         return article;


### PR DESCRIPTION
* 대댓글 도메인 설계
* 대댓글 도메인 변경으로 인한 data와 ArticleComment부분 수정과 대댓글 데이터 추가
* 대댓글 도메인 변경으로 인한 추가적인 Jpa테시트가 필요해 보여서 테스트 케이스 추가
* 대댓글 비지니스 로직 구현
* 댓글 컨트롤러 테스트에 대댓글 케이스 추가